### PR TITLE
Fixing testing issue: template folder location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ NEO-2-QL/.directory
 */[Bb]uild/*
 */[Bb]uild-*/*
 */[Bb]uild_*/*
+*/*/[Bb]uild/*
+*/*/[Bb]uild-*/*
+*/*/[Bb]uild_*/*
 
 # Ignore files created by latex.
 *.pdf

--- a/ShellScripts/test_full_reconstruct.sh
+++ b/ShellScripts/test_full_reconstruct.sh
@@ -7,7 +7,24 @@ testcase=${1}
 number_processors=${2}
 which_code=${3}
 
-testpath=`mktemp -d /temp/$LOGNAME/Neo2/Testing/Runs/Test-${testcase}-XXXXXX`
+# Check if the directory /temp/$LOGNAME/Neo2/Testing/Runs/ exists
+if [ ! -d "/temp/$LOGNAME/Neo2/Testing/Runs/" ] && [ -z "$NEO2_TEST_PATH" ]; then
+    echo "There is no directory defined for storing test data. Please create the /temp/$LOGNAME/Neo2/Testing/Runs/ directory or define a new location in the environment variable NEO2_TEST_PATH."
+    exit 1
+fi
+# Check if NEO2_TEST_PATH is defined
+if [ -n "$NEO2_TEST_PATH" ]; then
+    # Check if the directory defined in NEO2_TEST_PATH exists
+    if [ ! -d "$NEO2_TEST_PATH" ]; then
+        echo "The directory defined in NEO2_TEST_PATH does not exist. Please define an existing directory."
+        exit 1
+    fi
+fi
+if [ -d "/temp/$LOGNAME/Neo2/Testing/Runs/" ]; then
+    testpath=`mktemp -d /temp/$LOGNAME/Neo2/Testing/Runs/Test-${testcase}-XXXXXX`
+else
+    testpath=`mktemp -d $NEO2_TEST_PATH/Test-${testcase}-XXXXXX`
+fi
 echo "Testpath created: ${testpath}"
 
 referencepath='/temp/buchholz/Neo2/Testing/Reference/'
@@ -127,7 +144,8 @@ cp ./$executablename ${testpath}/
 cd ${testpath}/
 
 echo "Copying template..."
-cp -r -L ../../Template/${testcase}/* ./
+# From the saved test templates location (hard coded)
+cp -r -L /temp/AG-plasma/codes/neo-2_test_templates/${testcase}/* ./
 
 echo "Running Test ${testcase}..."
 


### PR DESCRIPTION
test_full_reconstruct.sh
* included check if necessary testing run folder or path is set as ENV
* changed template location to /temp/AG-plasma/codes to be accessible for all users
(still need to repair broken links)

Updated gitignore:
* should also ignore build folders in tools/create_surfaces subfolder