### PR TITLE
Change libneo path

### DIFF
--- a/NEO-2-PAR/CMakeLists.txt
+++ b/NEO-2-PAR/CMakeLists.txt
@@ -91,8 +91,8 @@ find_package(SuiteSparse REQUIRED)
 find_package(SuperLU REQUIRED)
 
 ### Find libraries
-find_library(libneo_lib neo ${NEO2_Libs}/src/ NO_DEFAULT_PATH)
-find_library(magfie_lib magfie ${NEO2_Libs}/src/ NO_DEFAULT_PATH)
+find_library(libneo_lib neo ${NEO2_Libs} NO_DEFAULT_PATH)
+find_library(magfie_lib magfie ${NEO2_Libs} NO_DEFAULT_PATH)
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 # GSL

--- a/NEO-2-QL/CMakeLists.txt
+++ b/NEO-2-QL/CMakeLists.txt
@@ -99,8 +99,8 @@ find_package(SuiteSparse REQUIRED)
 find_package(SuperLU REQUIRED)
 
 ### Find libraries
-find_library(libneo_lib neo ${NEO2_Libs}/src/ NO_DEFAULT_PATH)
-find_library(magfie_lib magfie ${NEO2_Libs}/src/ NO_DEFAULT_PATH)
+find_library(libneo_lib neo ${NEO2_Libs} NO_DEFAULT_PATH)
+find_library(magfie_lib magfie ${NEO2_Libs} NO_DEFAULT_PATH)
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 # GSL


### PR DESCRIPTION
While cleaning up and modernizing libneo build, the name and path of the main library changes from `liblibneo.so` to `src/libneo.so` 