### PR TITLE
Fix codecov configuration to find source directories

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,12 @@
 codecov:
   require_ci_to_pass: yes
+  # Specify directories to search for coverage
+  directory: .
+  # Specify source directories
+  paths:
+    - COMMON/
+    - NEO-2-PAR/
+    - NEO-2-QL/
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Configure codecov to find source code in COMMON/, NEO-2-PAR/, and NEO-2-QL/ directories
- Codecov was looking for default 'src' folder which doesn't exist in this project

## Changes
- Add explicit `paths` configuration to codecov.yml
- Set `directory: .` to ensure proper coverage collection from project root

## Test plan
- Codecov should now properly find and report coverage for files in the actual source directories
- CI workflow should continue to work as before

🤖 Generated with [Claude Code](https://claude.ai/code)