### PR TITLE
sister pull request to https://github.com/itpplasma/libneo/pull/112

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,9 +2,10 @@
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/71e55b695f624fd9b5e18f97acdf95fd)](https://app.codacy.com/gh/itpplasma/NEO-2/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
-# Installation
+## Installation
 
-## Prerequisites
+### Prerequisites
+
 git, cmake, make, ninja, gcc/g++/gfortran, MPI (OpenMPI or MPICH), BLAS/LAPACK (OpenBLAS or MKL), SuiteSparse, FFTW, GSL, HDF5/NetCDF with Fortran libraries. If SuiteSparse is not available on your system, it will be built automatically by NEO-2. For code coverage, lcov is also required. On Debian or Ubuntu run
 
     sudo apt install git cmake make ninja-build gcc g++ gfortran
@@ -13,7 +14,7 @@ git, cmake, make, ninja, gcc/g++/gfortran, MPI (OpenMPI or MPICH), BLAS/LAPACK (
     sudo apt install libfftw3-dev libgsl-dev libhdf5-dev libnetcdf-dev libnetcdff-dev
     sudo apt install lcov  # Optional, for code coverage
 
-## Build
+### Build
 
 Run
 
@@ -30,15 +31,11 @@ You obtain a `build` directory with subdirectories
 
 To run tests:
 
-```bash
     make test
-```
 
 To generate code coverage report:
 
-```bash
     make coverage
-```
 
 This will build with coverage instrumentation, run all tests, and display a coverage summary. Coverage data files are generated in the `build` directory.
 
@@ -60,7 +57,7 @@ If you have additional compilers and MPI implementations (e.g. Intel) installed,
 
 before the build. You may also need to `deactivate` Python environments such as Anaconda.
 
-# Run
+## Run
 
 NEO-2 requires Boozer files for MHD equilibria in text format (`.bc` ending). These can be generated via executables / functions in https://github.com/itpplasma/libneo/
 


### PR DESCRIPTION
### **User description**
sister pull request to https://github.com/itpplasma/libneo/pull/112


___

### **PR Type**
Documentation


___

### **Description**
- Restructure README heading hierarchy for consistency

- Convert top-level sections from H1 to H2 format

- Remove unnecessary code block markers from bash commands

- Add Prerequisites subsection under Installation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -->|"Update heading levels"| B["H1 to H2 conversion"]
  A -->|"Reorganize structure"| C["Add Prerequisites subsection"]
  A -->|"Simplify formatting"| D["Remove code block markers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Readme.md</strong><dd><code>Restructure heading hierarchy and remove code formatting</code>&nbsp; </dd></summary>
<hr>

Readme.md

<ul><li>Changed main section headings from H1 (#) to H2 (##) format for <br>Installation, Build, and Run sections<br> <li> Converted Prerequisites from H2 to H3 (###) subsection under <br>Installation<br> <li> Removed triple backtick code block markers around <code>make test</code> and <code>make </code><br><code>coverage</code> commands<br> <li> Added blank line after Installation heading for improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/NEO-2/pull/63/files#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

