### PR TITLE
export ql monoenergetic d11 and enable hdf5 efinal output

### DIFF
--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -29,7 +29,7 @@ module neo2_ql
        prop_diagphys,prop_overwrite,                                &
        prop_diagnostic,prop_binary,                                 &
        prop_timing,prop_join_ends,prop_fluxsplitmode,               &
-       prop_write,prop_reconstruct,prop_ripple_plot,                &
+       prop_write,prop_fileformat,prop_reconstruct,prop_ripple_plot,&
        prop_reconstruct_levels
   USE magnetics_mod, ONLY : mag_talk,mag_infotalk
   USE mag_interface_mod, ONLY : mag_local_sigma, hphi_lim,          &
@@ -238,7 +238,7 @@ module neo2_ql
        prop_fluxsplitmode,                                                    &
        mag_talk,mag_infotalk,                                                 &
        hphi_lim,                                                              &
-       prop_write,prop_reconstruct,prop_ripple_plot,                          &
+       prop_write,prop_fileformat,prop_reconstruct,prop_ripple_plot,          &
        prop_reconstruct_levels
   NAMELIST /plotting/                                                         &
        plot_gauss,plot_prop

--- a/NEO-2-QL/propagator.f90
+++ b/NEO-2-QL/propagator.f90
@@ -803,6 +803,7 @@ CONTAINS
     REAL(kind=dp) :: gamma_E
     REAL(kind=dp) :: aiota_loc,rt0
     REAL(kind=dp) :: phi
+    REAL(kind=dp) :: fac1, fac2, D11_ov_Dpl
 
     REAL(kind=dp), ALLOCATABLE :: y(:)
 
@@ -908,6 +909,12 @@ CONTAINS
             gamma_out
       CLOSE(uw)
 
+      fac1 = 16.0_dp * rt0 * aiota_loc / PI
+      fac2 = -beta_out(1) * beta_out(1) / y(6)
+      i_p = ind_map(1)
+      j_p = ind_map(1)
+      D11_ov_Dpl = fac1 * fac2 * prop_a%p%qflux(i_p, j_p)
+
       if (prop_fileformat .eq. USE_HDF5_FORMAT) then
         ! Write to HDF5 file
         call h5_create('efinal.h5', h5id, 1)
@@ -927,6 +934,7 @@ CONTAINS
         call h5_add(h5id, 'r0', device%r0)
         call h5_add(h5id, 'bmod0', surface%bmod0, comment='reference magnetic field in Tesla', unit='T')
         call h5_add(h5id, 'y', y, lbound(y), ubound(y))
+        call h5_add(h5id, 'D11_ov_Dpl', D11_ov_Dpl)
 
         call h5_close(h5id)
       else


### PR DESCRIPTION
## Summary
Export the tokamak monoenergetic `D11_ov_Dpl` quantity from `NEO-2-QL/efinal.h5` and expose `prop_fileformat` in the `QL` propagator namelist so HDF5 `efinal.h5` can be requested from normal `QL` runs.

## Why
The AUG 30835 `GORILLA_APPLETS` vs `NEO-2` axisymmetric comparison needs a clean monoenergetic `QL` output contract. Before this change:
- `NEO-2-QL` computed `D11_ov_Dpl`-relevant quantities internally but did not write `D11_ov_Dpl` to `efinal.h5`
- `prop_fileformat` existed in `propagator_mod` but was not readable from `NEO-2-QL/neo2.f90`, so requesting HDF5 `efinal.h5` via the input file failed

## Changes
- add `prop_fileformat` to the `QL` `/propagator/` namelist in `NEO-2-QL/neo2.f90`
- compute `D11_ov_Dpl` in `NEO-2-QL/propagator.f90` using the same local pattern already used on the `PAR` side
- write `D11_ov_Dpl` into `efinal.h5`

## Verification
```bash
$ cmake --build /home/ert/code/NEO-2/build -j$(nproc) --target neo_2_ql.x
[12/12] Linking Fortran executable NEO-2-QL/neo_2_ql.x
```

```bash
$ ./run_neo2.sh > run.log 2>&1
$ python /home/ert/data/AUG/NEO-2/30835/gorilla_axisymmetric_baseline/scripts/extract_neo2_par_monoenergetic.py \
    /home/ert/data/AUG/NEO-2/30835/gorilla_axisymmetric_baseline/runs/ql_two_surfaces/es_0p25271/efinal.h5
{
  "dmono_over_dplateau": -3.313532670952886e-05,
  "D11_ov_Dpl": -0.00018744171370511668
}
```
