### PR TITLE
Clarify rotation docs and restore PDF build

### DIFF
--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LATEX_DEFAULT_BUILD "SafePdf")
 
 project(neo-2-documentation)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/../cmake)
+
 find_package(LATEX)
 find_package(Doxygen
              REQUIRED dot

--- a/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
+++ b/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
@@ -727,9 +727,9 @@ generate_neo2_profile(hdf5FileName, path_to_shot, data_source, species_definitio
 Here \verb|isw_Vphi_loc = 0| means that the supplied rotation profile is the
 flux-surface Boozer toroidal angular frequency $\langle V^\varphi \rangle$,
 and \verb|species_tag_Vphi = 2| means that this measured rotation profile
-belongs to species 2. In the multispecies force-balance solve this is not a
-cosmetic label: the selected species provides the charge, temperature,
-density, and gradients that enter the \verb|compute_Er()| closure.
+belongs to species 2. In the multispecies force-balance solve the selected
+species provides the charge, temperature, density, and gradients that enter
+the \verb|compute_Er()| closure.
 
 Default for the DEMO
 runs was the profile file

--- a/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
+++ b/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
@@ -729,7 +729,9 @@ flux-surface Boozer toroidal angular frequency $\langle V^\varphi \rangle$,
 and \verb|species_tag_Vphi = 2| means that this measured rotation profile
 belongs to species 2. In the multispecies force-balance solve the selected
 species provides the charge, temperature, density, and gradients that enter
-the \verb|compute_Er()| closure.
+the \verb|compute_Er()| closure. The generated HDF5 profile files use positive
+species tags (\verb|1, 2, ...|), so \verb|species_tag_Vphi| must match one of
+those values in this workflow.
 
 Default for the DEMO
 runs was the profile file

--- a/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
+++ b/DOC/ExtraDocuments/neo-2-ql-demo_runs.tex
@@ -724,6 +724,13 @@ bounds = [0.0, 1.0];
 
 generate_neo2_profile(hdf5FileName, path_to_shot, data_source, species_definition, isw_Vphi_loc, species_tag_Vphi, input_unit_type, bounds);
 \end{verbatim}
+Here \verb|isw_Vphi_loc = 0| means that the supplied rotation profile is the
+flux-surface Boozer toroidal angular frequency $\langle V^\varphi \rangle$,
+and \verb|species_tag_Vphi = 2| means that this measured rotation profile
+belongs to species 2. In the multispecies force-balance solve this is not a
+cosmetic label: the selected species provides the charge, temperature,
+density, and gradients that enter the \verb|compute_Er()| closure.
+
 Default for the DEMO
 runs was the profile file
 \begin{verbatim}

--- a/DOC/UserDoc/Output.tex
+++ b/DOC/UserDoc/Output.tex
@@ -298,7 +298,7 @@ avbhat & \\
 \hline
 avbhat2 & \\
 \hline
-av_nabla_stor & \\
+av\_nabla\_stor & \\
 \hline
 bcovar\_phi & \\
 \hline

--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -151,7 +151,9 @@
  num_spec = 2 ! [1]
  r_vphi = 0.0 ! only used for isw_Vphi_loc=1 [0.0d0]
  species_tag_vec = 1, 2 ! [1,..,number of species]
- species_tag_vphi = 2 ! 0: species index should be the same for all flux surfaces [default]
+ species_tag_vphi = 2 ! Selects which species owns the measured rotation input Vphi inside compute_Er().
+                     ! The chosen species supplies the charge, thermodynamic profiles, gradients, and transport row
+                     ! used in the force-balance solve. 0: use one fixed species index for all flux surfaces [default]
  t_vec =  9.1495920740775243e-009,  7.1751185399075415e-009 ! List with the temperatures of the species in erg (1 erg ~ 6.241*10^11 eV). [1.6d-9]
  vphi = 77048.433690608756 ! [0.0d0]
  z_vec = -1.0,  1.0 ! List with the specific charges of the species. [1.0d0]

--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -153,7 +153,10 @@
  species_tag_vec = 1, 2 ! [1,..,number of species]
  species_tag_vphi = 2 ! Selects which species owns the measured rotation input Vphi inside compute_Er().
                      ! The chosen species supplies the charge, thermodynamic profiles, gradients, and transport row
-                     ! used in the force-balance solve. 0: use one fixed species index for all flux surfaces [default]
+                     ! used in the force-balance solve.
+                     ! In generated HDF5 multispecies inputs the valid tags are the entries in species_tag_vec,
+                     ! which are typically 1..num_species. A value of 0 is only meaningful in legacy namelist
+                     ! setups where species_tag_vec itself contains 0. [default]
  t_vec =  9.1495920740775243e-009,  7.1751185399075415e-009 ! List with the temperatures of the species in erg (1 erg ~ 6.241*10^11 eV). [1.6d-9]
  vphi = 77048.433690608756 ! [0.0d0]
  z_vec = -1.0,  1.0 ! List with the specific charges of the species. [1.0d0]


### PR DESCRIPTION
## Summary

- clarify what `species_tag_vphi` selects in the multispecies force-balance solve
- clarify the `isw_Vphi_loc = 0` and `species_tag_Vphi = 2` demo profile example
- fix the standalone documentation build from `DOC/` by wiring in the vendored `cmake/UseLATEX.cmake`
- fix the escaped underscore in `DOC/UserDoc/Output.tex` so the user manual LaTeX build completes again

## Verification

### Documentation build fails on main
```bash
$ cmake -S DOC -B DOC/Build -G Ninja && cmake --build DOC/Build -j2
-- Found LATEX: /usr/bin/latex
-- Found Doxygen: /usr/bin/doxygen (found version "1.16.1") found components: doxygen dot missing components: mscgen dia
CMake Error at CMakeLists.txt:32 (include):
  include could not find requested file:

    UseLATEX

CMake Error at CMakeLists.txt:35 (add_latex_document):
  Unknown CMake command "add_latex_document".
```

### Documentation build passes after fix
```bash
$ cmake -S DOC -B DOC/Build -G Ninja && cmake --build DOC/Build -j2
-- Build files have been written to: /home/ert/code/NEO-2/DOC/Build
[9/10] ... ps2pdf14 ... main.ps main.pdf
[10/10] Generating Doxygen_Reference_Manual.pdf
Output written on refman.pdf (768 pages, 4600660 bytes).
```

## Resulting PDFs

The documented CMake path now produces:

- `DOC/Build/main.pdf`
- `DOC/Build/neo-2-ql-demo_runs.pdf`
- `DOC/Build/neo-2-par-eccd_runs.pdf`
- `DOC/Build/Doxygen_Reference_Manual.pdf`
