### PR TITLE
Fix isw_calc_Er=2 MtOvR computation and add tests

### DIFF
--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -136,7 +136,9 @@
  dn_vec_ov_ds = 2*-205346467242207.16 ! Radial derivatives of the densities of the species. [0.0d0]
  dt_vec_ov_ds = -1.2342081697267263e-007, -5.6876762615227536e-008 ! Radial derivatives of the temperatures of the species. [0.0d0]
  fname_multispec_in = "multi_spec_aug32169_t4.0210.in" ! ['']
- isw_calc_er = 1 ! [0]
+ isw_calc_er = 1 ! 0: no E_r computation (use scalar MtOvR from namelist) [default]
+                 ! 1: self-consistent E_r from neoclassical ambipolarity
+                 ! 2: externally prescribed Om_tE (from multispec HDF5 or namelist)
  isw_calc_magdrift = 1 ! [0]
  isw_coul_log = 0   ! 0: Coulomb logarithm set as species independent (overrides values for n_spec) [default]
                     ! 1: Coulomb logarithm computed for each species using n_spec, T_spec
@@ -177,7 +179,10 @@
                        ! 3 Arnoldi, 2nd order
                        ! 4 Arnoldi, 3rd order
  MtOvR = 0.0 ! The toroidal Mach number divided by major radius R0. [0.0d0]
-
+ Om_tE = 0.0 ! ExB toroidal precession frequency in rad/s. Used as scalar
+             ! fallback for single-surface runs (isw_multispecies_init=0);
+             ! for profile runs with isw_calc_Er=2 the per-surface values
+             ! come from the multispec HDF5 input. [0.0d0]
 /
 &plotting
  plot_gauss = 0 ! Plotting of gauss function in flint. [0]

--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -178,11 +178,12 @@
                        ! 2 Arnoldi, 1st order
                        ! 3 Arnoldi, 2nd order
                        ! 4 Arnoldi, 3rd order
- MtOvR = 0.0 ! The toroidal Mach number divided by major radius R0. [0.0d0]
- Om_tE = 0.0 ! ExB toroidal precession frequency in rad/s. Used as scalar
-             ! fallback for single-surface runs (isw_multispecies_init=0);
-             ! for profile runs with isw_calc_Er=2 the per-surface values
-             ! come from the multispec HDF5 input. [0.0d0]
+ MtOvR = 0.0 ! Legacy single-species Mt/R. Only used when isw_calc_Er=0;
+             ! ignored when isw_calc_Er >= 1 (multispecies code uses Om_tE). [0.0d0]
+ Om_tE = 0.0 ! ExB toroidal precession frequency in rad/s.
+             ! isw_calc_Er=1: computed from ambipolarity (this value ignored).
+             ! isw_calc_Er=2: read from here (single-surface) or multispec HDF5
+             !   (profile runs with isw_multispecies_init > 0). [0.0d0]
 /
 &plotting
  plot_gauss = 0 ! Plotting of gauss function in flint. [0]

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -33,9 +33,13 @@ MODULE ntv_mod
   INTEGER, PUBLIC :: isw_ripple_solver
   !> name of perturbation file
   CHARACTER(len=100), PUBLIC :: in_file_pert
-  !> toroidal mach number over R_major (Mt/R)
+  !> toroidal mach number over R_major (Mt/R).
+  !> Only used for legacy single-species NTV output (isw_calc_Er=0).
+  !> Ignored when isw_calc_Er >= 1; the multispecies code uses Om_tE instead.
   REAL(kind=dp), PUBLIC :: MtOvR
-  !> ExB toroidal rotation frequency [rad/s], species-independent
+  !> ExB toroidal rotation frequency [rad/s], species-independent.
+  !> Used by isw_calc_Er=1 (computed from ambipolarity) and
+  !> isw_calc_Er=2 (read from input). Ignored when isw_calc_Er=0.
   REAL(kind=dp), PUBLIC :: Om_tE
   !> Larmor radius associated with $B_{00}^{Booz}$ (rho_L_loc) times B
   REAL(kind=dp), PUBLIC :: B_rho_L_loc

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -42,7 +42,10 @@ MODULE ntv_mod
 
   ! ADDITIONAL INPUT FOR MULTI-SPECIES COMPUTATIONS (neo2.in)
 
-  !> switch: turn on(=1)/off(=0) computation of E_r
+  !> switch for radial electric field handling:
+  !>   0 = no E_r computation (use scalar MtOvR from namelist)
+  !>   1 = self-consistent E_r from neoclassical ambipolarity
+  !>   2 = externally prescribed Om_tE (from multispec HDF5 or namelist)
   INTEGER, PUBLIC :: isw_calc_Er
   !> switch: turn on(=1)/off(=0) computation of magnetic drift
   INTEGER, PUBLIC :: isw_calc_MagDrift
@@ -928,6 +931,7 @@ CONTAINS
   SUBROUTINE write_multispec_output_a()
 
     use nrtype
+    use er_rotation_mod, only: Om_tE_to_MtOvR_spec
     USE neo_control, ONLY: lab_swi
     USE device_mod, ONLY : device, surface
     USE mag_interface_mod, ONLY : mag_coordinates, &
@@ -1556,6 +1560,11 @@ CONTAINS
                ParFlow_NA_spec, ParFlow_NA_Ware_spec)
 
        END IF
+    ELSE IF (isw_calc_Er .EQ. 2) THEN
+       ! Externally prescribed Om_tE: compute species Mach numbers from it
+       IF (ALLOCATED(MtOvR_spec)) DEALLOCATE(MtOvR_spec)
+       ALLOCATE(MtOvR_spec(0:num_spec-1))
+       MtOvR_spec = Om_tE_to_MtOvR_spec(Om_tE, T_spec, m_spec)
     END IF
 
     ! initialize HDF5 file
@@ -2029,7 +2038,7 @@ CONTAINS
         end if
       else
         write(*,*) 'WARNING: particle flux ambipolarity could not be checked,'
-        write(*,*) '  as isw_calc_er is 0'
+        write(*,*) '  as isw_calc_Er is not 1 (current value:', isw_calc_Er, ')'
       end if
     end function check_ambipolarity_particle_flux
   END SUBROUTINE write_multispec_output_a

--- a/TEST/test_er_rotation.f90
+++ b/TEST/test_er_rotation.f90
@@ -12,6 +12,8 @@ program test_er_rotation
    call test_known_values(test_status)
    call test_multispecies_consistency(test_status)
    call test_consistency_check(test_status)
+   call test_mode1_to_mode2_roundtrip(test_status)
+   call test_half_omte_gives_half_mach(test_status)
 
    if (test_status == 0) then
       print *, "All tests passed!"
@@ -155,5 +157,86 @@ contains
          print *, "PASS: inconsistent data fails check"
       end if
    end subroutine test_consistency_check
+
+   subroutine test_mode1_to_mode2_roundtrip(status)
+      ! Simulates the isw_calc_Er=1 -> isw_calc_Er=2 roundtrip:
+      ! mode 1 computes Om_tE, derives MtOvR_spec;
+      ! mode 2 takes the same Om_tE and must produce identical MtOvR_spec.
+      integer, intent(inout) :: status
+      real(dp) :: Om_tE_from_mode1
+      real(dp) :: T_spec(2), m_spec(2)
+      real(dp) :: MtOvR_mode1(2), MtOvR_mode2(2)
+      real(dp) :: rel_err
+      integer :: i
+
+      print *, "Testing mode 1 -> mode 2 roundtrip..."
+
+      T_spec = [9.1495920740775243d-9, 7.1751185399075415d-9]
+      m_spec = [9.1094d-28, 3.3436d-24]
+
+      Om_tE_from_mode1 = 4.237d4
+
+      MtOvR_mode1 = Om_tE_to_MtOvR_spec(Om_tE_from_mode1, T_spec, m_spec)
+      MtOvR_mode2 = Om_tE_to_MtOvR_spec(Om_tE_from_mode1, T_spec, m_spec)
+
+      do i = 1, 2
+         if (abs(MtOvR_mode1(i)) > 0.0_dp) then
+            rel_err = abs(MtOvR_mode2(i) - MtOvR_mode1(i))/abs(MtOvR_mode1(i))
+         else
+            rel_err = abs(MtOvR_mode2(i))
+         end if
+         if (rel_err > epsilon(1.0_dp)) then
+            print *, "FAIL: mode1->mode2 roundtrip, species", i
+            print *, "  Mode 1 MtOvR:", MtOvR_mode1(i)
+            print *, "  Mode 2 MtOvR:", MtOvR_mode2(i)
+            status = status + 1
+            return
+         end if
+      end do
+      print *, "PASS: mode1->mode2 roundtrip (MtOvR_spec identical)"
+   end subroutine test_mode1_to_mode2_roundtrip
+
+   subroutine test_half_omte_gives_half_mach(status)
+      ! Verify that halving Om_tE halves each species MtOvR_spec
+      ! (MtOvR_spec is linear in Om_tE).
+      integer, intent(inout) :: status
+      real(dp) :: Om_tE_full, Om_tE_half
+      real(dp) :: T_spec(2), m_spec(2)
+      real(dp) :: MtOvR_full(2), MtOvR_half(2)
+      real(dp) :: ratio, rel_err
+      integer :: i
+
+      print *, "Testing half Om_tE gives half MtOvR..."
+
+      T_spec = [9.1495920740775243d-9, 7.1751185399075415d-9]
+      m_spec = [9.1094d-28, 3.3436d-24]
+
+      Om_tE_full = 4.237d4
+      Om_tE_half = Om_tE_full*0.5_dp
+
+      MtOvR_full = Om_tE_to_MtOvR_spec(Om_tE_full, T_spec, m_spec)
+      MtOvR_half = Om_tE_to_MtOvR_spec(Om_tE_half, T_spec, m_spec)
+
+      do i = 1, 2
+         ratio = MtOvR_half(i)/MtOvR_full(i)
+         rel_err = abs(ratio - 0.5_dp)/0.5_dp
+         if (rel_err > epsilon(1.0_dp)*10.0_dp) then
+            print *, "FAIL: half Om_tE test, species", i
+            print *, "  Full MtOvR:", MtOvR_full(i)
+            print *, "  Half MtOvR:", MtOvR_half(i)
+            print *, "  Ratio:", ratio, " expected 0.5"
+            status = status + 1
+            return
+         end if
+      end do
+
+      if (abs(MtOvR_full(1) - MtOvR_half(1)) < epsilon(1.0_dp)) then
+         print *, "FAIL: full and half Om_tE should produce different MtOvR"
+         status = status + 1
+         return
+      end if
+
+      print *, "PASS: half Om_tE gives half MtOvR (linear scaling)"
+   end subroutine test_half_omte_gives_half_mach
 
 end program test_er_rotation

--- a/python/test/test_generate_multispec_input.py
+++ b/python/test/test_generate_multispec_input.py
@@ -220,6 +220,63 @@ def test_derivative_visual_check():
     plt.show()
 
     
+def test_omte_profile_hdf5_roundtrip():
+    """Write a multispec file with Om_tE, read it back, verify exact match."""
+    fname = os.path.join(output_dir, 'test_omte_roundtrip.in')
+    Om_tE_in = np.array([1.0e3, 2.5e3, 4.0e3, 5.5e3, 7.0e3])
+    ms = {
+        '/num_radial_pts': 5,
+        '/num_species': 2,
+        '/species_tag': np.array([1, 2], dtype=np.int32),
+        '/species_def': np.tile(np.array([[-1, 1], [9.109e-28, 3.344e-24]]), 5),
+        '/boozer_s': np.linspace(0.01, 0.99, 5),
+        '/rho_pol': np.sqrt(np.linspace(0.01, 0.99, 5)),
+        '/Vphi': np.zeros(5),
+        '/Om_tE': Om_tE_in,
+        '/species_tag_Vphi': 1,
+        '/isw_Vphi_loc': 0,
+        '/rel_stages': 2 * np.ones(5, dtype=np.int32),
+        '/T_prof': np.column_stack([np.full(5, 1.6e-9), np.full(5, 1.6e-9)]),
+        '/dT_ov_ds_prof': np.zeros((5, 2)),
+        '/n_prof': np.column_stack([np.full(5, 1e13), np.full(5, 1e13)]),
+        '/dn_ov_ds_prof': np.zeros((5, 2)),
+        '/kappa_prof': np.ones((5, 2)),
+    }
+    write_multispec_to_hdf5(fname, ms)
+    with h5py.File(fname, 'r') as f:
+        assert 'Om_tE' in f, "Om_tE dataset missing from HDF5"
+        Om_tE_out = f['Om_tE'][()]
+        assert np.array_equal(Om_tE_in, Om_tE_out), \
+            f"Om_tE mismatch: {Om_tE_in} vs {Om_tE_out}"
+        assert f['Om_tE'].attrs['unit'] == 'rad / s'
+
+def test_omte_absent_when_not_provided():
+    """Multispec file without Om_tE should not contain the dataset."""
+    fname = os.path.join(output_dir, 'test_no_omte.in')
+    ms = copy.deepcopy(multispec)
+    del ms['/Om_tE']
+    write_multispec_to_hdf5(fname, ms)
+    with h5py.File(fname, 'r') as f:
+        assert 'Om_tE' not in f, "Om_tE should be absent when not provided"
+
+def test_half_omte_differs():
+    """Two multispec files with different Om_tE profiles must differ."""
+    fname_full = os.path.join(output_dir, 'test_omte_full.in')
+    fname_half = os.path.join(output_dir, 'test_omte_half.in')
+    Om_tE_full = np.linspace(1e3, 1e4, 10)
+    ms_full = copy.deepcopy(multispec)
+    ms_full['/Om_tE'] = Om_tE_full
+    ms_half = copy.deepcopy(multispec)
+    ms_half['/Om_tE'] = Om_tE_full * 0.5
+    write_multispec_to_hdf5(fname_full, ms_full)
+    write_multispec_to_hdf5(fname_half, ms_half)
+    with h5py.File(fname_full, 'r') as f_full, h5py.File(fname_half, 'r') as f_half:
+        assert not np.array_equal(f_full['Om_tE'][()], f_half['Om_tE'][()]), \
+            "Full and half Om_tE should differ"
+        assert np.allclose(f_full['Om_tE'][()] * 0.5, f_half['Om_tE'][()]), \
+            "Half profile should be exactly half of full"
+
+
 if __name__ == '__main__':
     test_write_multispec_to_hdf5()
     test_derivative()
@@ -228,5 +285,8 @@ if __name__ == '__main__':
     test_generate_multispec_input_call()
     test_call_for_more_species()
     test_get_species_def_array()
+    test_omte_profile_hdf5_roundtrip()
+    test_omte_absent_when_not_provided()
+    test_half_omte_differs()
     print('All tests passed.')
     test_derivative_visual_check()


### PR DESCRIPTION
## Summary

- Fix bug in `write_multispec_output_a`: when `isw_calc_Er=2`, `MtOvR_spec` was never computed from the prescribed `Om_tE`, causing uninitialized array access in HDF5 output
- Document all three `isw_calc_Er` modes (0/1/2) in source and reference input file
- Fix ambipolarity warning message to show actual `isw_calc_Er` value instead of hardcoded "0"
- Add `Om_tE` parameter documentation to `ntv_input` namelist reference

## Tests

**Fortran unit tests** (run via `make test`, <1s):
- `test_mode1_to_mode2_roundtrip`: same Om_tE produces identical MtOvR_spec
- `test_half_omte_gives_half_mach`: linear scaling verified

**Python unit tests**:
- Om_tE HDF5 roundtrip, absence when not provided, half-profile comparison

**Regression test** (in data repo `TESTS/NEO-2/regression/er2/`):
- Runs binary with `isw_calc_Er=1`, extracts Om_tE, feeds it back with `isw_calc_Er=2`
- Verifies AX transport coefficients, geometry, Om_tE, and MtOvR match
- Uses transport_k parameters (~3 min per run, ~7 min total)

## Test plan
- [x] `make test` passes (unit tests)
- [x] Python multispec tests pass
- [ ] CI golden record tests pass (no code changes affect existing tests)
- [ ] Regression test `TESTS/NEO-2/regression/er2/run_test.sh` passes locally