### PR TITLE
Resolve libneo via LIBNEO_REF override, default to release branch

### DIFF
--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -2,6 +2,7 @@
 set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
+set(LIBNEO_RELEASE release/26.2 CACHE STRING "libneo release branch to track")
 find_or_fetch(libneo)
 
 ### Path to the external libraries

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -7,9 +7,17 @@ function(find_or_fetch DEPENDENCY)
     else()
         set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
 
-        # Check if a specific git tag is provided for this dependency
+        # Ref precedence: <DEP>_BRANCH (cache or env) overrides everything so an
+        # upstream release can build this code against a candidate; then a pinned
+        # <DEP>_GIT_TAG; otherwise the matching-branch default.
         string(TOUPPER ${DEPENDENCY} DEPENDENCY_UPPER)
-        if(DEFINED ${DEPENDENCY_UPPER}_GIT_TAG)
+        if(DEFINED ${DEPENDENCY_UPPER}_BRANCH AND NOT "${${DEPENDENCY_UPPER}_BRANCH}" STREQUAL "")
+            set(REMOTE_BRANCH "${${DEPENDENCY_UPPER}_BRANCH}")
+            message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
+        elseif(DEFINED ENV{${DEPENDENCY_UPPER}_BRANCH} AND NOT "$ENV{${DEPENDENCY_UPPER}_BRANCH}" STREQUAL "")
+            set(REMOTE_BRANCH "$ENV{${DEPENDENCY_UPPER}_BRANCH}")
+            message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
+        elseif(DEFINED ${DEPENDENCY_UPPER}_GIT_TAG)
             set(REMOTE_BRANCH ${${DEPENDENCY_UPPER}_GIT_TAG})
             message(STATUS "Using ${DEPENDENCY} tag ${REMOTE_BRANCH} from ${REPO_URL}")
         else()

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -1,65 +1,97 @@
 include(FetchContent)
 
+# Resolve a first-party itpplasma dependency and add it to the build.
+#
+# Ref precedence (first match wins):
+#   1. <DEP>_REF      cache or env: a branch, tag or commit, validated against the
+#                     remote and ignored if absent. An upstream release sets this
+#                     to build this code against a candidate ref.
+#   2. <DEP>_GIT_TAG  cache: an explicit pinned tag (e.g. reference builds).
+#   3. <DEP>_RELEASE  cache: the release branch this code tracks by default.
+#   4. the current branch if it exists in the remote, otherwise main.
+#
+# The dependency is always fetched at the resolved ref; there is no local-path
+# shortcut.
 function(find_or_fetch DEPENDENCY)
-    if(DEFINED ENV{CODE} AND EXISTS $ENV{CODE}/${DEPENDENCY})
-        set(${DEPENDENCY}_SOURCE_DIR $ENV{CODE}/${DEPENDENCY})
-        message(STATUS "Using ${DEPENDENCY} in $ENV{CODE}/${DEPENDENCY}")
-    else()
-        set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
+    set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
+    string(TOUPPER ${DEPENDENCY} _DEP)
 
-        # Ref precedence: <DEP>_BRANCH (cache or env) overrides everything so an
-        # upstream release can build this code against a candidate; then a pinned
-        # <DEP>_GIT_TAG; otherwise the matching-branch default.
-        string(TOUPPER ${DEPENDENCY} DEPENDENCY_UPPER)
-        if(DEFINED ${DEPENDENCY_UPPER}_BRANCH AND NOT "${${DEPENDENCY_UPPER}_BRANCH}" STREQUAL "")
-            set(REMOTE_BRANCH "${${DEPENDENCY_UPPER}_BRANCH}")
-            message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
-        elseif(DEFINED ENV{${DEPENDENCY_UPPER}_BRANCH} AND NOT "$ENV{${DEPENDENCY_UPPER}_BRANCH}" STREQUAL "")
-            set(REMOTE_BRANCH "$ENV{${DEPENDENCY_UPPER}_BRANCH}")
-            message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
-        elseif(DEFINED ${DEPENDENCY_UPPER}_GIT_TAG)
-            set(REMOTE_BRANCH ${${DEPENDENCY_UPPER}_GIT_TAG})
-            message(STATUS "Using ${DEPENDENCY} tag ${REMOTE_BRANCH} from ${REPO_URL}")
-        else()
-            get_branch_or_main(${REPO_URL} REMOTE_BRANCH)
-            message(STATUS "Using ${DEPENDENCY} branch ${REMOTE_BRANCH} from ${REPO_URL}")
-        endif()
-
-        FetchContent_Declare(
-            ${DEPENDENCY}
-            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-            GIT_REPOSITORY ${REPO_URL}
-            GIT_TAG ${REMOTE_BRANCH}
-        )
-        FetchContent_Populate(${DEPENDENCY})
+    set(_ref "")
+    set(_override "")
+    if(DEFINED ${_DEP}_REF AND NOT "${${_DEP}_REF}" STREQUAL "")
+        set(_override "${${_DEP}_REF}")
+    elseif(DEFINED ENV{${_DEP}_REF} AND NOT "$ENV{${_DEP}_REF}" STREQUAL "")
+        set(_override "$ENV{${_DEP}_REF}")
     endif()
+    if(NOT "${_override}" STREQUAL "")
+        execute_process(
+            COMMAND git ls-remote ${REPO_URL} ${_override}
+            OUTPUT_VARIABLE _found
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(NOT "${_found}" STREQUAL "")
+            set(_ref "${_override}")
+        else()
+            message(WARNING "${_DEP}_REF='${_override}' not found in ${REPO_URL}; ignoring")
+        endif()
+    endif()
+    if("${_ref}" STREQUAL "" AND DEFINED ${_DEP}_GIT_TAG)
+        set(_ref "${${_DEP}_GIT_TAG}")
+    endif()
+    if("${_ref}" STREQUAL "" AND DEFINED ${_DEP}_RELEASE AND NOT "${${_DEP}_RELEASE}" STREQUAL "")
+        set(_ref "${${_DEP}_RELEASE}")
+    endif()
+    if("${_ref}" STREQUAL "")
+        get_branch_or_main(${REPO_URL} _ref)
+    endif()
+    message(STATUS "Using ${DEPENDENCY} ref ${_ref} from ${REPO_URL}")
 
-    add_subdirectory(${${DEPENDENCY}_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY}
-        EXCLUDE_FROM_ALL
+    # Fetched first-party dependencies are linked as libraries, not test hosts.
+    set(LIBNEO_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+    set(LIBNEO_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+    set(LIBNEO_ENABLE_GOLDEN_TESTS OFF CACHE BOOL "" FORCE)
+
+    FetchContent_Declare(
+        ${DEPENDENCY}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        GIT_REPOSITORY ${REPO_URL}
+        GIT_TAG ${_ref}
     )
+    FetchContent_GetProperties(${DEPENDENCY})
+    if(NOT ${DEPENDENCY}_POPULATED)
+        FetchContent_Populate(${DEPENDENCY})
+        add_subdirectory(${${DEPENDENCY}_SOURCE_DIR}
+            ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY}
+            EXCLUDE_FROM_ALL
+        )
+    endif()
 endfunction()
 
-
-function(get_branch_or_main REPO_URL REMOTE_BRANCH)
-    execute_process(
-        COMMAND git rev-parse --abbrev-ref HEAD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE BRANCH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    execute_process(
-        COMMAND git ls-remote --heads ${REPO_URL} ${BRANCH}
-        OUTPUT_VARIABLE BRANCH_EXISTS
-        ERROR_VARIABLE GIT_ERROR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    if(BRANCH_EXISTS)
-        set(${REMOTE_BRANCH} ${BRANCH} PARENT_SCOPE)
+function(get_branch_or_main REPO_URL OUT)
+    if(DEFINED ENV{GITHUB_HEAD_REF} AND NOT "$ENV{GITHUB_HEAD_REF}" STREQUAL "")
+        set(_branch "$ENV{GITHUB_HEAD_REF}")
+    elseif(DEFINED ENV{GITHUB_REF_NAME} AND NOT "$ENV{GITHUB_REF_NAME}" STREQUAL "")
+        set(_branch "$ENV{GITHUB_REF_NAME}")
     else()
-        message(STATUS "No branch ${BRANCH} at ${REPO_URL}. Return main instead!")
-        set(${REMOTE_BRANCH} "main" PARENT_SCOPE)
+        execute_process(
+            COMMAND git rev-parse --abbrev-ref HEAD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE _branch
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+    if("${_branch}" STREQUAL "" OR "${_branch}" STREQUAL "HEAD")
+        set(${OUT} "main" PARENT_SCOPE)
+        return()
+    endif()
+    execute_process(
+        COMMAND git ls-remote --heads ${REPO_URL} ${_branch}
+        OUTPUT_VARIABLE _exists
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT "${_exists}" STREQUAL "")
+        set(${OUT} "${_branch}" PARENT_SCOPE)
+    else()
+        set(${OUT} "main" PARENT_SCOPE)
     endif()
 endfunction()


### PR DESCRIPTION
Resolves the libneo dependency ref with this precedence:

1. `LIBNEO_REF` (cache or env) - a branch, tag or commit, validated against the remote; ignored if absent instead of failing the fetch. An upstream libneo release sets this to build NEO-2 against a candidate.
2. the committed `LIBNEO_RELEASE` (`release/26.2`) - the libneo release branch this code tracks. Never libneo main.

Renames the override from `LIBNEO_BRANCH` to `LIBNEO_REF` since it accepts any git ref. Companion CI change adds the matching `workflow_dispatch` trigger.