### PR TITLE
besselk: back gsl_specialfunctions_mod by fortnum bessel_kn

### DIFF
--- a/COMMON/gsl_specialfunctions_mod.f90
+++ b/COMMON/gsl_specialfunctions_mod.f90
@@ -2,15 +2,17 @@
 ! module: gsl_specialfunctions_mod                                                        !
 ! authors: TU Graz ITPcp Plasma, Andreas F. Martitsch                                            !
 ! date: 14.03.2017                                                                        !
-! version: 0.1                                                                            !
+! version: 0.2                                                                            !
 !-----------------------------------------------------------------------------------------!
 !-----------------------------------------------------------------------------------------!
 ! History                                                                                 !
 ! 0.1 - Initial version for modified Bessel function of second kind                       !
+! 0.2 - Backend moved from FGSL to fortnum (bessel_kn)                                     !
 !-----------------------------------------------------------------------------------------!
 
 module gsl_specialfunctions_mod
-  use fgsl
+  use, intrinsic :: iso_fortran_env, only: wp => real64
+  use fortnum_special, only: bessel_kn
 
   implicit none
 
@@ -18,9 +20,9 @@ module gsl_specialfunctions_mod
 
   function besselk(n, z)
     integer :: n
-    real(fgsl_double) :: z, besselk
+    real(wp) :: z, besselk
 
-    besselk = fgsl_sf_bessel_kcn(n, z)
+    besselk = bessel_kn(n, z)
 
   end function besselk
 


### PR DESCRIPTION
## Scope

Replace the FGSL backend of `besselk(n, z)` in `gsl_specialfunctions_mod` with the fortnum special-function routine `bessel_kn`. The module name and the public `besselk` function name are unchanged, so `COMMON/collop_compute.f90` (which evaluates orders 0, 1, 2) compiles without edits. The internal real kind moves from `fgsl_double` to `iso_fortran_env` `real64` (aliased `wp`).

## Dependency removed

FGSL `fgsl_sf_bessel_kcn` (and the `use fgsl` it pulled in) for the modified Bessel function of the second kind.

## Verification

fortnum built at `a7faa3c` via `fo build` (exit 0). The migrated module compiled standalone against the fortnum module path:

```
$ gfortran -c -ffree-line-length-none -I$CODE/fortnum/build/include \
    COMMON/gsl_specialfunctions_mod.f90
exit: 0
```

The object references only fortnum, no GSL/FGSL:

```
$ nm gsl_specialfunctions_mod.o | grep -iE " U " | grep -iE "gsl|fgsl|amos|slatec|fftw"
(no output)
$ nm gsl_specialfunctions_mod.o | grep -ic fortnum
1
```

## Unverified

Full NEO-2 executable link is not exercised in this PR (it lands with the CMake wiring at the tip of the stack). The local `libneo` checkout cannot configure NEO-2 here because `libneo`'s `src/magfie/CMakeLists.txt` links the `FFTW::DoubleThreads` target, which is not created when `libneo` is consumed via `add_subdirectory` in this environment (present on `libneo` main, independent of this change).
