### PR TITLE
MyMPILib: initialize workunit fracIndex

### DIFF
--- a/COMMON/MyMPILib/Generic/workunit_module.f90
+++ b/COMMON/MyMPILib/Generic/workunit_module.f90
@@ -7,7 +7,7 @@ module workunit_module
   implicit none
   
   type, extends(packable), abstract :: workunit
-    real    :: fracIndex        !< Required for special purposes (correct sort order for matrix multiplication)
+    real    :: fracIndex = 0    !< Required for special purposes (correct sort order for matrix multiplication)
     character(len=1024) :: type = ''        !< Defines the type of the workunit to allocate the correct class. Has to be unique!
     integer :: client = -1      !< Defines the client on which the workunit will run
     integer :: oldClient = -1   !< Defines the client which was suspected to run the workunit, but has maybe changed by loadbalancing


### PR DESCRIPTION
## Problem

Intermittent `SIGSEGV` in the worker workunit scheduler during golden-record runs (seen in CI on the lorentz PAR case). Backtrace:

```
__list_module_MOD_addnode_list        COMMON/MyMPILib/Tools/list_module.f90:277
__wulist_module_MOD_add_workunitlist  COMMON/MyMPILib/Tools/wuList_module.f90:84
__scheduler_module_MOD_rebuildwu_scheduler   scheduler_generic.f90
__scheduler_module_MOD_dolisten_wulistener
__scheduler_module_MOD_initclient_scheduler
__scheduler_module_MOD_schedule_scheduler
flint_                                NEO-2-PAR/flint.f90:2234
```

## Root cause

`fracIndex` is the only field of the abstract `workunit` type declared without a default initializer (`workunit_module.f90`). The scheduler sets it on the master (`= proptag_start`) but it is never packed, so after a worker unpacks a received workunit its `fracIndex` is **uninitialized**.

The worker then inserts the workunit into its waiting list, which is sorted by `fracIndex` via `addnode_list`. When the uninitialized value happens to be a NaN bit pattern, every ordering comparison (`<=`, `>`) is false. The sorted insert falls through to `arrow => arrow%getPrev()`, which is null for the head element, and the next line dereferences it (`arrow%next => newNode`, list_module.f90:277).

Whether the uninitialized memory holds a NaN depends on heap layout, so the crash is intermittent and surfaces when an unrelated change shifts allocations.

## Fix

Default-initialize `fracIndex` to `0`, matching every other field of the type. The master still assigns `proptag_start` before use, so scheduling order is unchanged; only the previously-undefined worker value becomes deterministic.

## Verification

Reproduced deterministically by forcing the worker's `fracIndex` to NaN immediately after unpack (a one-line throwaway diagnostic), then running the lorentz golden record:

Before (NaN `fracIndex`):
```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
#3  __list_module_MOD_addnode_list  ...  list_module.f90:277
#4  __wulist_module_MOD_add_workunitlist  ...  wuList_module.f90:84
rc=139, no efinal.h5
```
This matches the CI backtrace exactly.

After (this fix, diagnostic removed), lorentz golden record, 5 consecutive runs:
```
run 1: rc=0 segfault=0 efinal=y
run 2: rc=0 segfault=0 efinal=y
run 3: rc=0 segfault=0 efinal=y
run 4: rc=0 segfault=0 efinal=y
run 5: rc=0 segfault=0 efinal=y
```

Note: `-finit-real=nan` does not catch this, because it does not initialize derived-type components reached through `allocate` (it covers local intrinsic variables at scope entry; component coverage needs `-finit-derived`, and neither touches `ALLOCATE`d storage). The Fortran-standard mechanism is the type's default initializer, which is what this adds.