### PR TITLE
CI: install h5py for unit-tests jobs

### DIFF
--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy
+          pip install numpy h5py
 
 
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy
+          pip install numpy h5py
 
       - name: Build NEO-2
         run: |


### PR DESCRIPTION
## Summary
- `python/test/test_compute_omte.py` (added on #76) reads an `.h5` fixture via `h5py`.
- The `unit-tests` and `unit-tests-coverage` workflows' Python setup step only installed `numpy`, so that test fails with `ModuleNotFoundError: No module named 'h5py'`.
- Add `h5py` to both setup steps.

## Verification
- Failing before: `unit-tests` check on #76 fails with `ModuleNotFoundError: No module named 'h5py'` in `test_compute_omte.py`.
- Fix: `pip install numpy h5py` in `.github/workflows/unit-tests.yml` and `.github/workflows/unit-tests-coverage.yml`.