### PR TITLE
python: declare scipy dependency, install it in CI

### DIFF
--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy h5py
+          pip install numpy h5py scipy
 
 
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy h5py
+          pip install numpy h5py scipy
 
       - name: Build NEO-2
         run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "numpy>=1.20.0",
     "omfit_classes>=3.2023.47.2",
     "libneo>=0.0.3",
-    "h5py>=3.10.0"
+    "h5py>=3.10.0",
+    "scipy>=1.7.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- `neo2_ql/get_integral_ntv.py` imports `scipy.integrate.cumulative_trapezoid`, but `python/pyproject.toml` never declared `scipy` as a dependency.
- `python_compute_omte_test` (added on #76) runs `python/test/run_compute_omte_checks.py` directly via `PYTHONPATH`, not through the installed package, so it hits the missing import even with `pyproject.toml` fixed.
- Add `scipy` to `pyproject.toml` dependencies and to the `unit-tests`/`unit-tests-coverage` CI pip installs.

## Verification
- Failing before: `unit-tests` on #76 fails with `ModuleNotFoundError: No module named 'scipy'` (surfaced only after the h5py fix in #108 cleared the prior missing-module error).
- Fix: declare `scipy>=1.7.0` in `python/pyproject.toml`, `pip install numpy h5py scipy` in both workflow files.