### PR TITLE
ci: key workflow_dispatch concurrency by run, not workflow name

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ on:
         default: ''
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- libneo's downstream-gate workflow dispatches `unit-tests.yml` via `workflow_dispatch` on every libneo PR to test that PR's commit against NEO-2.
- `concurrency.group` falls back to `github.ref` for `workflow_dispatch` events, which is constant (`refs/heads/main`) regardless of the triggering libneo PR/commit. Concurrent dispatches from different libneo PRs land in the same group, and `cancel-in-progress: true` kills all but the last one — even though each dispatch tests an independent, unrelated libneo commit.
- Observed: 5 dispatched runs within 7 seconds all landed in the same group; 4 were cancelled, only the last survived. The cancelled runs made libneo's gate falsely report those PRs as red.
- Key `workflow_dispatch` runs by `github.run_id` (unique per run) so they never collide. `pull_request`/`push` events keep their existing behavior unchanged.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/unit-tests.yml'))"` — YAML parses
- [ ] Confirm concurrent libneo-triggered dispatches no longer cancel each other