### PR TITLE
python: declare matplotlib dependency, install it in CI

### DIFF
--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy h5py scipy
+          pip install numpy h5py scipy matplotlib
 
 
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python 3
         run: |
           python -m pip install --upgrade pip
-          pip install numpy h5py scipy
+          pip install numpy h5py scipy matplotlib
 
       - name: Build NEO-2
         run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "omfit_classes>=3.2023.47.2",
     "libneo>=0.0.3",
     "h5py>=3.10.0",
-    "scipy>=1.7.0"
+    "scipy>=1.7.0",
+    "matplotlib>=3.4.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- `neo2_ql/plot_omte_reference.py` imports `matplotlib.pyplot`, reached transitively from `python_compute_omte_test` (added on #76) via `neo2_ql.plot_omte_reference`.
- Same gap as the h5py (#108) and scipy (#109) fixes: not declared in `python/pyproject.toml`, not installed by the `unit-tests`/`unit-tests-coverage` CI jobs.
- Add `matplotlib` to both.

## Verification
- Failing before: `unit-tests` on #76 fails with `ModuleNotFoundError: No module named 'matplotlib'` (surfaced only after #108/#109 cleared the prior missing-module errors in the same import chain).
- Fix: declare `matplotlib>=3.4.0` in `python/pyproject.toml`, `pip install numpy h5py scipy matplotlib` in both workflow files.