### PR TITLE
cquad: clamp integrand abscissa to the open segment

### DIFF
--- a/COMMON/gsl_integration_routines_mod.f90
+++ b/COMMON/gsl_integration_routines_mod.f90
@@ -671,8 +671,14 @@ CONTAINS
       ! Check, whether C-pointer 'params' is not associated (no parameter passed)
       IF(C_ASSOCIATED(params)) STOP '***Error*** in f2c_wrapper_func1d_param0'
 
-      ! Wrap user-specified function to a C-interoperable function
-      f2c_wrapper_func1d_param0 = func1d_param0_user(x)
+      ! Wrap user-specified function to a C-interoperable function.
+      ! Clamp the abscissa to the open interval: the node arithmetic of the
+      ! quadrature rule can land one ulp outside [x_low, x_up], where the
+      ! collision-operator integrands jump at a B-spline knot shared with the
+      ! neighbouring segment.
+      f2c_wrapper_func1d_param0 = func1d_param0_user( &
+           MIN(MAX(x, NEAREST(x_low, 1.0_fgsl_double)), &
+           NEAREST(x_up, -1.0_fgsl_double)))
 
     END FUNCTION f2c_wrapper_func1d_param0
   END FUNCTION fint1d_param0_cquad
@@ -752,8 +758,12 @@ CONTAINS
 
       ! Cast C-pointer to the above-defined Fortran pointer
       CALL C_F_POINTER(params, p)
-      ! Wrap user-specified function to a C-interoperable function
-      f2c_wrapper_func1d_param1 = func1d_param1_user(x,p)
+      ! Wrap user-specified function to a C-interoperable function.
+      ! Clamp the abscissa to the open interval (see f2c_wrapper_func1d_param0
+      ! of fint1d_param0_cquad).
+      f2c_wrapper_func1d_param1 = func1d_param1_user( &
+           MIN(MAX(x, NEAREST(x_low, 1.0_fgsl_double)), &
+           NEAREST(x_up, -1.0_fgsl_double)), p)
 
     END FUNCTION f2c_wrapper_func1d_param1
   END FUNCTION fint1d_param1_cquad


### PR DESCRIPTION
## Problem

The Clenshaw-Curtis node arithmetic of CQUAD (`mid + half*cos(theta)`) can land one ulp outside the requested interval. The collision-operator matrix-element integrands jump exactly at the B-spline knots that bound each integration segment (order-2 basis, piecewise-constant derivatives) - that is why `integrate()` splits at `t_vec` in the first place. A one-ulp overshoot therefore samples the neighbouring knot cell, where the integrand is up to ~5e5 instead of 0; the rule chases the phantom kink and a spurious contribution of order 1e-10 relative survives in `denmm`/`ailmm`, amplified to the 1e-6 level in downstream transport coefficients.

Traced call-by-call and evaluation-by-evaluation during the ql golden-record case with two quadrature backends running side by side in one process (3.07M integrator calls): every divergent call sits on a knot-bounded segment, e.g. segment start `a = 8/3 = 2.66666666666666652`, first CQUAD evaluation at `x = 2.66666666666666607` (one ulp below `a`, integrand 5.4e5 there, identically 0 on the whole segment). The resulting spurious value depends on how the subdivision cascade happens to round its nodes - a numerical artifact, not physics.

## Fix

Clamp every integrand evaluation one ulp inside the segment (`NEAREST(x_low, +1)`, `NEAREST(x_up, -1)`) in the two `fint1d_cquad` wrappers. The segment integrand is then continuous on the closed interval and the quadrature resolves it to machine precision. The Gauss-Kronrod paths (`fint1d_qag*`, `fint1d_qagiu`) sample strictly interior nodes and need no clamp.

## Verification

ql golden-record case run locally on this machine, current vs reference summary compared at 1e-15, where current is a fortnum-backed quadrature build (PR #97 stack) and reference is this GSL build - i.e. the worst-case cross-backend comparison that exposes the artifact:

Before (both sides unclamped):

```
Difference in ailmm_aa: 3.567174273426909e-08
Difference in gamma_out: 1.438353670282282e-07
Difference in D12_AX: 2.7679199051000286e-06
1756 of 3.07M traced integrator calls divergent (rel diff > 1e-13)
```

After (both sides clamped):

```
Difference in ailmm_aa: 7.760368610542252e-11
Difference in gamma_out: 1.471679456239206e-09
Difference in D12_AX: 1.5306089679022486e-09
0 traced calls above the same threshold; residual is <= 3 ulp per segment
integral, i.e. the last-bit difference of two correct quadratures amplified
by cancellation in the segment sums.
```

Unit tests: `make test` 4/4.

## CI note

This PR's own exact check against current main must come out red: removing the sliver artifact shifts lorentz `denmm`/`ailmm` by ~5e-10 relative against an unclamped reference, which is far above the 1e-14 gate. The same holds for the stable-release check until a release contains this fix, and the lorentz legacy comparison (tolerance 1e-10) sits exactly at the artifact size. Landing this is a prerequisite for the fortnum quadrature stack (#95-#99) to compare cleanly against main.
