### PR TITLE
QL: reset equation-matrix storage before rebuild

### DIFF
--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -53,7 +53,8 @@ subroutine ripple_solver_ArnoldiO2( &
                              irow_per_neg, icol_per_neg, &
                              irow_asymm, icol_asymm, amat_asymm, &
                              f0_coll, f0_ttmp, f0_coll_all, f0_ttmp_all, &
-                             nz_regper, irow_regper, icol_regper, amat_regper
+                             nz_regper, irow_regper, icol_regper, amat_regper, &
+                             deallocate_ntv_eqmat
     use partpa_mod, only: bmod0
     use development
   !! Modifications by Andreas F. Martitsch (12.03.2014)
@@ -1861,6 +1862,8 @@ subroutine ripple_solver_ArnoldiO2( &
         end do
 
     end do
+
+    call deallocate_ntv_eqmat()
 
     allocate (irow(nz), icol(nz), amat_sp(nz))
     allocate (irow_coll(nz_coll), icol_coll(nz_coll), amat_coll(nz_coll))

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -12,6 +12,26 @@
     complex(kind=kind(1d0)), DIMENSION(:), ALLOCATABLE :: amat_asymm
     DOUBLE PRECISION, DIMENSION(:,:),   ALLOCATABLE :: f0_coll,f0_ttmp
     DOUBLE PRECISION, DIMENSION(:,:,:), ALLOCATABLE :: f0_coll_all,f0_ttmp_all
+  CONTAINS
+    SUBROUTINE deallocate_ntv_eqmat()
+      IF (ALLOCATED(irow_symm)) DEALLOCATE(irow_symm)
+      IF (ALLOCATED(icol_symm)) DEALLOCATE(icol_symm)
+      IF (ALLOCATED(amat_symm)) DEALLOCATE(amat_symm)
+      IF (ALLOCATED(irow_regper)) DEALLOCATE(irow_regper)
+      IF (ALLOCATED(icol_regper)) DEALLOCATE(icol_regper)
+      IF (ALLOCATED(amat_regper)) DEALLOCATE(amat_regper)
+      IF (ALLOCATED(irow_asymm)) DEALLOCATE(irow_asymm)
+      IF (ALLOCATED(icol_asymm)) DEALLOCATE(icol_asymm)
+      IF (ALLOCATED(amat_asymm)) DEALLOCATE(amat_asymm)
+      IF (ALLOCATED(irow_per_pos)) DEALLOCATE(irow_per_pos)
+      IF (ALLOCATED(icol_per_pos)) DEALLOCATE(icol_per_pos)
+      IF (ALLOCATED(irow_per_neg)) DEALLOCATE(irow_per_neg)
+      IF (ALLOCATED(icol_per_neg)) DEALLOCATE(icol_per_neg)
+      IF (ALLOCATED(f0_coll)) DEALLOCATE(f0_coll)
+      IF (ALLOCATED(f0_ttmp)) DEALLOCATE(f0_ttmp)
+      IF (ALLOCATED(f0_coll_all)) DEALLOCATE(f0_coll_all)
+      IF (ALLOCATED(f0_ttmp_all)) DEALLOCATE(f0_ttmp_all)
+    END SUBROUTINE deallocate_ntv_eqmat
   END MODULE ntv_eqmat_mod
 
 !Sergei 20.07.2006 : modification of boundary layer is done now locally,
@@ -63,7 +83,8 @@ SUBROUTINE ripple_solver(                                 &
   ! MPI SUPPORT for multi-species part
   ! (run with, e.g.,  mpiexec -np 3 ./neo2.x)
   USE ntv_eqmat_mod, ONLY : nz_symm,irow_symm,icol_symm,amat_symm,             &
-                            nz_regper,irow_regper,icol_regper,amat_regper
+                            nz_regper,irow_regper,icol_regper,amat_regper,     &
+                            deallocate_ntv_eqmat
   use mpiprovider_module, only : mpro
   USE collop
   !! End Modification by Andreas F. Martitsch (28.07.2015)
@@ -1967,6 +1988,8 @@ PRINT *,'right boundary layer ignored'
 
   enddo
 
+
+  CALL deallocate_ntv_eqmat()
 
   allocate(irow(nz),icol(nz),amat_sp(nz),ipcol(ncol),bvec_sp(ncol))
   allocate(irow_regper(nz_regper),icol_regper(nz_regper),amat_regper(nz_regper))


### PR DESCRIPTION
## Summary
- add a cleanup routine for persistent `ntv_eqmat_mod` storage
- call it before the axi and Arnoldi QL solvers rebuild equation matrices
- add a focused reset unit test

## Verification
### Test fails on main
With only the new regression test applied to `origin/main`:
```text
$ cmake --preset default -DCMAKE_COLOR_DIAGNOSTICS=ON -DCMAKE_BUILD_TYPE=Release && cmake --build --preset default --target test_ntv_eqmat_reset
Error: Symbol ‘deallocate_ntv_eqmat’ referenced at (1) not found in module ‘ntv_eqmat_mod’
ninja: build stopped: subcommand failed.
```

### Test passes after fix
```text
$ make test
Test project build/TEST
    Start 1: boozmn_read_test
1/6 Test #1: boozmn_read_test .................   Passed
    Start 2: nrutil_test
2/6 Test #2: nrutil_test ......................   Passed
    Start 3: er_rotation_test
3/6 Test #3: er_rotation_test .................   Passed
    Start 4: ntv_eqmat_reset_test
4/6 Test #4: ntv_eqmat_reset_test .............   Passed
    Start 5: spline_sparse_assembly_test
5/6 Test #5: spline_sparse_assembly_test ......   Passed
    Start 6: test_mympilib
6/6 Test #6: test_mympilib ....................   Passed

100% tests passed, 0 tests failed out of 6
```