### PR TITLE
QL: retain propagator join solver diagnostics

### DIFF
--- a/COMMON/collision_operator_mems.f90
+++ b/COMMON/collision_operator_mems.f90
@@ -502,6 +502,7 @@ module collop
       if (allocated(denmm_a)) deallocate(denmm_a)
       if (allocated(Inbi_lmmp_a)) deallocate(Inbi_lmmp_a)
       if (allocated(asource)) deallocate(asource)
+      if (allocated(asource_hel)) deallocate(asource_hel)
       if (allocated(weightlag)) deallocate(weightlag)
       if (allocated(x1mm)) deallocate(x1mm)
       if (allocated(x2mm)) deallocate(x2mm)

--- a/COMMON/collop_compute.f90
+++ b/COMMON/collop_compute.f90
@@ -1507,6 +1507,7 @@ contains
   end subroutine compute_Minv
 
   subroutine compute_sources(asource_s, weightlag_s, weightden_s, weightparflow_s, weightenerg_s)
+    use rkstep_mod, only : asource_hel
     real(kind=dp), dimension(:,:), intent(out) :: asource_s, weightlag_s
     real(kind=dp), dimension(:), intent(out)   :: weightden_s, weightparflow_s, weightenerg_s
     real(kind=dp) :: res_int
@@ -1543,6 +1544,31 @@ contains
     end if
 
     call chop(asource_s)
+
+    ! Moments of the single-helicity misalignment drive (weights x^-1, x^2);
+    ! always computed by quadrature, no precomputed-matrix-element path.
+    if (allocated(asource_hel)) deallocate(asource_hel)
+    allocate(asource_hel(0:lagmax, 2))
+    if (isw_relativistic .eq. 0) then
+       do k = 1, 2
+          do m = 0, lagmax
+             asource_hel(m, k) = integrate(am_hel, 0d0)
+          end do
+       end do
+    else
+       do k = 1, 2
+          do m = 0, lagmax
+             asource_hel(m, k) = norm_maxwell * integrate(am_hel_rel1, 0d0)
+          end do
+       end do
+    end if
+    if (make_ortho) then
+       do k = 1, 2
+          asource_hel(:,k) = matmul(M_transform_inv, asource_hel(:,k))
+       end do
+    end if
+    call chop(asource_hel)
+
     write (*,*) "Computing weighting coefficients..."
 
     if (allocated(C_m)) deallocate(C_m)
@@ -1614,6 +1640,24 @@ contains
 
       am = pi**(-3d0/2d0) * x**(4+alpha) * exp(-(1+beta)*x**2) * phi_prj(m, x) * x**(2*k - 1 - 5*kdelta(3,k))
     end function am
+
+    ! Misalignment-drive weights x^(3k-4): k=1 -> x^-1, k=2 -> x^2
+    function am_hel(x)
+      real(kind=dp) :: x, am_hel
+
+      am_hel = pi**(-3d0/2d0) * x**(4+alpha) * exp(-(1+beta)*x**2) * phi_prj(m, x) * x**(3*k - 4)
+    end function am_hel
+
+    function am_hel_rel1(x)
+      real(kind=dp) :: x, am_hel_rel1
+      real(kind=dp) :: exp_maxwell, gam
+
+      exp_maxwell = 2d0/(sqrt(1+2*x**2/rmu) + 1)
+      gam = sqrt(1 + 2*x**2/rmu)
+
+      am_hel_rel1 = 1d0/gam * pi**(-3d0/2d0) * x**(4+alpha) * exp(-(exp_maxwell+beta)*x**2) &
+           * phi_prj(m, x) * x**(3*k - 4)
+    end function am_hel_rel1
 
     function am_rel1(x)
       real(kind=dp) :: x, am_rel1

--- a/COMMON/collop_compute.f90
+++ b/COMMON/collop_compute.f90
@@ -1546,28 +1546,31 @@ contains
     call chop(asource_s)
 
     ! Moments of the single-helicity misalignment drive (weights x^-1, x^2);
-    ! always computed by quadrature, no precomputed-matrix-element path.
-    if (allocated(asource_hel)) deallocate(asource_hel)
-    allocate(asource_hel(0:lagmax, 2))
-    if (isw_relativistic .eq. 0) then
-       do k = 1, 2
-          do m = 0, lagmax
-             asource_hel(m, k) = integrate(am_hel, 0d0)
+    ! computed by quadrature only (left unallocated on the precomputed
+    ! matrix-element path; the solver rejects the drive in that case).
+    if (.not. precomp) then
+       if (allocated(asource_hel)) deallocate(asource_hel)
+       allocate(asource_hel(0:lagmax, 2))
+       if (isw_relativistic .eq. 0) then
+          do k = 1, 2
+             do m = 0, lagmax
+                asource_hel(m, k) = integrate(am_hel, 0d0)
+             end do
           end do
-       end do
-    else
-       do k = 1, 2
-          do m = 0, lagmax
-             asource_hel(m, k) = norm_maxwell * integrate(am_hel_rel1, 0d0)
+       else
+          do k = 1, 2
+             do m = 0, lagmax
+                asource_hel(m, k) = norm_maxwell * integrate(am_hel_rel1, 0d0)
+             end do
           end do
-       end do
+       end if
+       if (make_ortho) then
+          do k = 1, 2
+             asource_hel(:,k) = matmul(M_transform_inv, asource_hel(:,k))
+          end do
+       end if
+       call chop(asource_hel)
     end if
-    if (make_ortho) then
-       do k = 1, 2
-          asource_hel(:,k) = matmul(M_transform_inv, asource_hel(:,k))
-       end do
-    end if
-    call chop(asource_hel)
 
     write (*,*) "Computing weighting coefficients..."
 
@@ -1641,11 +1644,12 @@ contains
       am = pi**(-3d0/2d0) * x**(4+alpha) * exp(-(1+beta)*x**2) * phi_prj(m, x) * x**(2*k - 1 - 5*kdelta(3,k))
     end function am
 
-    ! Misalignment-drive weights x^(3k-4): k=1 -> x^-1, k=2 -> x^2
+    ! Misalignment-drive weights x^(3k-4): k=1 -> x^-1, k=2 -> x^2.
+    ! Powers folded into one factor so the x=0 quadrature node stays finite.
     function am_hel(x)
       real(kind=dp) :: x, am_hel
 
-      am_hel = pi**(-3d0/2d0) * x**(4+alpha) * exp(-(1+beta)*x**2) * phi_prj(m, x) * x**(3*k - 4)
+      am_hel = pi**(-3d0/2d0) * x**(3*k + alpha) * exp(-(1+beta)*x**2) * phi_prj(m, x)
     end function am_hel
 
     function am_hel_rel1(x)
@@ -1655,8 +1659,8 @@ contains
       exp_maxwell = 2d0/(sqrt(1+2*x**2/rmu) + 1)
       gam = sqrt(1 + 2*x**2/rmu)
 
-      am_hel_rel1 = 1d0/gam * pi**(-3d0/2d0) * x**(4+alpha) * exp(-(exp_maxwell+beta)*x**2) &
-           * phi_prj(m, x) * x**(3*k - 4)
+      am_hel_rel1 = 1d0/gam * pi**(-3d0/2d0) * x**(3*k + alpha) * exp(-(exp_maxwell+beta)*x**2) &
+           * phi_prj(m, x)
     end function am_hel_rel1
 
     function am_rel1(x)

--- a/COMMON/flint_mod.f90
+++ b/COMMON/flint_mod.f90
@@ -899,7 +899,7 @@ contains
     INTEGER,       INTENT(inout) :: phi_eta_ind(0:u_eta,2)
 
     INTEGER :: ub
-    INTEGER :: iphi,idiv,cphi,cdiv,ieta
+    INTEGER :: iphi,idiv,cphi,cdiv,ieta,refinement_scale
     INTEGER, ALLOCATABLE :: phi_eta_ind_loc(:,:)
     REAL(kind=dp) :: hphi
     REAL(kind=dp), ALLOCATABLE :: phi(:)
@@ -910,6 +910,8 @@ contains
     phi_eta_ind_loc = phi_eta_ind
 
     ub   = UBOUND(fieldpropagator%coords%x2,1)
+    refinement_scale = 1
+    IF (MOD(SUM(phi_divide(1:ub)),2) .NE. 0) refinement_scale = 2
     ALLOCATE(phi(0:ub))
     phi    = fieldpropagator%coords%x2
     IF (ALLOCATED(phiarr)) DEALLOCATE(phiarr)
@@ -918,7 +920,7 @@ contains
     CALL set_new(phi_p,phi(0))
     cphi = 0 ! counter
     philoop: DO iphi = 1,ub
-       cdiv = phi_divide(iphi)
+       cdiv = refinement_scale*phi_divide(iphi)
        hphi = phi(iphi) - phi(iphi-1)
        divloop: DO idiv = 1,cdiv
           cphi = cphi + 1

--- a/COMMON/rkstep_mod.f90
+++ b/COMMON/rkstep_mod.f90
@@ -5,6 +5,10 @@ MODULE rkstep_mod
   CHARACTER(len=3), DIMENSION(:), ALLOCATABLE       :: species_tags
   DOUBLE PRECISION, DIMENSION(:,:),     ALLOCATABLE :: Amm
   DOUBLE PRECISION, DIMENSION(:,:),     ALLOCATABLE :: asource
+  ! Velocity moments of the single-helicity misalignment drive
+  ! (column 1: weight x^-1, ExB piece / A1 channel;
+  !  column 2: weight x^2, vpar corrugation piece / A2 channel)
+  DOUBLE PRECISION, DIMENSION(:,:),     ALLOCATABLE :: asource_hel
   DOUBLE PRECISION, DIMENSION(:,:,:),   ALLOCATABLE, TARGET :: anumm_a
   DOUBLE PRECISION, DIMENSION(:,:,:),   ALLOCATABLE, TARGET :: denmm_a
   DOUBLE PRECISION, DIMENSION(:,:,:,:), ALLOCATABLE, TARGET :: anumm_aa

--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -167,9 +167,12 @@
 &ntv_input
  B_rho_L_loc = 0.0 ! Larmor radius times magnetic field. [0.0d0]
  in_file_pert = 'filename' ! File that contains perturbation of the
-                           ! magnetic field.
+                           ! magnetic field. Use 'none' for source-only
+                           ! non-axisymmetric runs with prescribed m_phi.
  isw_mag_shear = 1 ! Turn on(=1)/off(=0) non-local computations (mag.
                    ! shear). [0]
+ isw_m_phi_input = 0 ! Use m_phi_input instead of the perturbation-file mode.
+                     ! Required when in_file_pert='none'. [0]
  isw_ntv_mode = 1  ! [0]
  isw_qflux_NA = 1 ! Turn on(=1)/off(=0) computation of non-axisymmetrix
                   ! part. [0]
@@ -178,6 +181,7 @@
                        ! 2 Arnoldi, 1st order
                        ! 3 Arnoldi, 2nd order
                        ! 4 Arnoldi, 3rd order
+ m_phi_input = 0 ! Toroidal mode number used when isw_m_phi_input=1. [0]
  MtOvR = 0.0 ! Legacy single-species Mt/R. Only used when isw_calc_Er=0;
              ! ignored when isw_calc_Er >= 1 (multispecies code uses Om_tE). [0.0d0]
  Om_tE = 0.0 ! ExB toroidal precession frequency in rad/s.

--- a/DOC/neo2.in.ql-full
+++ b/DOC/neo2.in.ql-full
@@ -188,6 +188,17 @@
              ! isw_calc_Er=1: computed from ambipolarity (this value ignored).
              ! isw_calc_Er=2: read from here (single-surface) or multispec HDF5
              !   (profile runs with isw_multispecies_init > 0). [0.0d0]
+ isw_hel_drive = 0 ! Turn on(=1)/off(=0) the single-helicity misalignment
+                   ! drive (additional RHS of the non-axisymmetric equation
+                   ! set: radial corrugation + electrostatic harmonic). [0]
+ m_theta_hel = 0 ! Poloidal mode number m of the misalignment-drive
+                 ! harmonic; toroidal mode number n is m_phi from the file
+                 ! or m_phi_input. [0]
+ hel_brad_re = 0.0 ! Re of the corrugation amplitude (delta B^s/B_0^phi)_mn,
+                   ! dimensionless flux-function amplitude. [0.0d0]
+ hel_brad_im = 0.0 ! Im of the corrugation amplitude. [0.0d0]
+ hel_phim_re = 0.0 ! Re of the electrostatic harmonic Phi_mn in statvolt. [0.0d0]
+ hel_phim_im = 0.0 ! Im of the electrostatic harmonic Phi_mn in statvolt. [0.0d0]
 /
 &plotting
  plot_gauss = 0 ! Plotting of gauss function in flint. [0]

--- a/NEO-2-PAR/CMakeLists.txt
+++ b/NEO-2-PAR/CMakeLists.txt
@@ -48,3 +48,23 @@ ADD_TEST(Test_par_cubic_splines-Seq ${PROJECT_SOURCE_DIR}/../ShellScripts/test_f
 ADD_TEST(Test_par_cubic_splines-Par ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "par_cubic_splines" "6")
 ADD_TEST(Test_par_general_bsplines-Seq ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "par_general_bsplines" "0")
 ADD_TEST(Test_par_general_bsplines-Par ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "par_general_bsplines" "6")
+
+set(EXTERNAL_DATA_TESTS
+  Test_Testcase1-Seq
+  Test_Testcase1-Par
+  Test_Relativistic_BeliaevBudker-Seq
+  Test_Relativistic_BeliaevBudker-Par
+  Test_Relativistic_BraamsKarney-Seq
+  Test_Relativistic_BraamsKarney-Par
+  Test_par_standard_polynomials-Seq
+  Test_par_standard_polynomials-Par
+  Test_par_quadratic_polynomials-Seq
+  Test_par_quadratic_polynomials-Par
+  Test_par_cubic_splines-Seq
+  Test_par_cubic_splines-Par
+  Test_par_general_bsplines-Seq
+  Test_par_general_bsplines-Par
+)
+set_tests_properties(${EXTERNAL_DATA_TESTS} PROPERTIES
+  LABELS "regression;external-data"
+)

--- a/NEO-2-PAR/CMakeLists.txt
+++ b/NEO-2-PAR/CMakeLists.txt
@@ -33,6 +33,7 @@ if (COPY_TO_ARCHIVE)
 endif()
 
 ADD_TEST(NAME Test_Build_Code COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR})
+set_tests_properties(Test_Build_Code PROPERTIES RESOURCE_LOCK neo2_build_tree)
 ADD_TEST(Test_Testcase1-Seq       ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Testcase1" "0")
 ADD_TEST(Test_Testcase1-Par       ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Testcase1" "6")
 ADD_TEST(Test_Relativistic_BeliaevBudker-Seq ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Relativistic_BeliaevBudker" "0")

--- a/NEO-2-PAR/ripple_solver.f90
+++ b/NEO-2-PAR/ripple_solver.f90
@@ -33,8 +33,7 @@ SUBROUTINE ripple_solver(                                 &
                             lsw_save_spitf
   USE sparse_mod, ONLY : sparse_talk,sparse_solve_method,sparse_solve, &
        column_full2pointer,remap_rc,sparse_solver_test
-  USE mag_interface_mod, ONLY: average_bhat,average_one_over_bhat,             &
-                               surface_boozer_B00,travis_convfac,              &
+  USE mag_interface_mod, ONLY: surface_boozer_B00,travis_convfac,              &
                                mag_magfield
        
   USE development

--- a/NEO-2-QL/CMakeLists.txt
+++ b/NEO-2-QL/CMakeLists.txt
@@ -32,6 +32,7 @@ add_custom_target(copy
   )
 
 ADD_TEST(NAME Test_Build_Code COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR})
+set_tests_properties(Test_Build_Code PROPERTIES RESOURCE_LOCK neo2_build_tree)
 ADD_TEST(Extended_QL_Multispecies  ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Extended_QL_Multispecies" "2" "QL")
 ADD_TEST(Extended_QL_Multispecies_Read  ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Extended_QL_Multispecies_Read" "2" "QL")
 set_tests_properties(

--- a/NEO-2-QL/CMakeLists.txt
+++ b/NEO-2-QL/CMakeLists.txt
@@ -34,4 +34,9 @@ add_custom_target(copy
 ADD_TEST(NAME Test_Build_Code COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR})
 ADD_TEST(Extended_QL_Multispecies  ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Extended_QL_Multispecies" "2" "QL")
 ADD_TEST(Extended_QL_Multispecies_Read  ${PROJECT_SOURCE_DIR}/../ShellScripts/test_full_reconstruct.sh "Extended_QL_Multispecies_Read" "2" "QL")
+set_tests_properties(
+  Extended_QL_Multispecies
+  Extended_QL_Multispecies_Read
+  PROPERTIES LABELS "regression;external-data"
+)
 #ADD_TEST(Extended_QL_Multispecies  ${CMAKE_SOURCE_DIR}/../ShellScripts/test_scan.sh "Extended_QL_Scan_Kink" "QL")

--- a/NEO-2-QL/CMakeSources.in
+++ b/NEO-2-QL/CMakeSources.in
@@ -6,6 +6,7 @@ set(NEO2_QL_SRC_FILES
   flint.f90
   ripple_solver_axi_test.f90
   ripple_solver_ArnoldiOrder2_test.f90
+  join_diagnostics_mod.f90
   join_ripples_int.f90
   join_ripples.f90
   join_ends.f90

--- a/NEO-2-QL/join_diagnostics_mod.f90
+++ b/NEO-2-QL/join_diagnostics_mod.f90
@@ -1,0 +1,27 @@
+module join_diagnostics_mod
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    implicit none
+    private
+
+    public :: report_join_failure
+
+contains
+
+    subroutine report_join_failure(stage, info, old_tags, new_tags, ndim, ndim1, &
+            matrix, rhs, ierr)
+        integer, intent(in) :: stage, info, old_tags(2), new_tags(2), ndim, ndim1
+        real(kind(1.0d0)), intent(in) :: matrix(:, :), rhs(:, :)
+        integer, intent(out) :: ierr
+
+        write(*, '(a,i0)') 'join_ripples: DGBSV stage=', stage
+        write(*, '(a,i0)') 'join_ripples: DGBSV info=', info
+        write(*, '(a,2(1x,i0))') 'join_ripples: old propagator tags=', old_tags
+        write(*, '(a,2(1x,i0))') 'join_ripples: new propagator tags=', new_tags
+        write(*, '(a,2(1x,i0))') 'join_ripples: dimensions=', ndim, ndim1
+        write(*, '(a,i0,a,i0)') 'join_ripples: finite matrix entries=', &
+            count(ieee_is_finite(matrix)), '/', size(matrix)
+        write(*, '(a,i0,a,i0)') 'join_ripples: finite rhs entries=', &
+            count(ieee_is_finite(rhs)), '/', size(rhs)
+        ierr = stage
+    end subroutine report_join_failure
+end module join_diagnostics_mod

--- a/NEO-2-QL/join_ripples.f90
+++ b/NEO-2-QL/join_ripples.f90
@@ -19,6 +19,7 @@ SUBROUTINE join_ripples(ierr)
   USE propagator_mod
   USE lapack_band
   USE collisionality_mod, ONLY : isw_lorentz
+  USE join_diagnostics_mod, ONLY : report_join_failure
 USE development
 
   IMPLICIT NONE
@@ -138,7 +139,10 @@ USE development
   CALL gbsv(ndim,ndim,amat,ipivot,bvec_lapack,info)
 
   IF(info.NE.0) THEN
-    ierr=2
+    CALL report_join_failure(2,info,                                      &
+         [o%fieldpropagator_tag_s,o%fieldpropagator_tag_e],              &
+         [n%fieldpropagator_tag_s,n%fieldpropagator_tag_e],              &
+         ndim,ndim1,amat,bvec_lapack,ierr)
     RETURN
   ENDIF
 
@@ -179,7 +183,10 @@ USE development
   ! solution bvec_lapack -> $\ifour{\Fmat}{+}{}{o+1}{l,l}$
   CALL gbsv(ndim,ndim,amat,ipivot,bvec_lapack,info)
   IF(info.NE.0) THEN
-    ierr=3
+    CALL report_join_failure(3,info,                                      &
+         [o%fieldpropagator_tag_s,o%fieldpropagator_tag_e],              &
+         [n%fieldpropagator_tag_s,n%fieldpropagator_tag_e],              &
+         ndim,ndim1,amat,bvec_lapack,ierr)
     RETURN
   ENDIF
 
@@ -232,7 +239,10 @@ USE development
   ! solution bvec_lapack -> $\ifour{\Fmat}{+}{}{o+1}{r,l}$
   CALL gbsv(ndim,ndim,amat,ipivot,bvec_lapack,info)
   IF(info.NE.0) THEN
-    ierr=4
+    CALL report_join_failure(4,info,                                      &
+         [o%fieldpropagator_tag_s,o%fieldpropagator_tag_e],              &
+         [n%fieldpropagator_tag_s,n%fieldpropagator_tag_e],              &
+         ndim,ndim1,amat,bvec_lapack,ierr)
     RETURN
   ENDIF
 

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -67,7 +67,8 @@ module neo2_ql
        isw_Vphi_loc, Vphi, R_Vphi, Z_Vphi, boozer_theta_Vphi,       &
        dn_spec_ov_ds, dT_spec_ov_ds,                                &
        isw_hel_drive, m_theta_hel, hel_brad_re, hel_brad_im,        &
-       hel_phim_re, hel_phim_im, has_perturbation_file
+       hel_phim_re, hel_phim_im, has_perturbation_file,             &
+       has_helical_drive_source
 
   ! derivative of iota for non-local NTV computations
   ! (with magnetic shear)
@@ -952,9 +953,7 @@ subroutine main
     end if
 
     if (isw_qflux_NA == 1 .and. .not. has_perturbation_file()) then
-      if (isw_hel_drive == 0 .or. &
-          (hel_phim_re == 0.0d0 .and. hel_phim_im == 0.0d0 .and. &
-           hel_brad_re == 0.0d0 .and. hel_brad_im == 0.0d0)) then
+      if (.not. has_helical_drive_source()) then
         write(*,*) 'ERROR: non-axisymmetric solve has no source.'
         write(*,*) "  isw_qflux_NA=1 with in_file_pert='none' provides no"
         write(*,*) '  perturbation field, and the helical drive is off or zero.'

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -61,10 +61,11 @@ module neo2_ql
   USE sparse_mod, ONLY : sparse_talk,sparse_solve_method,sparse_example
   ! Extra input for NTV computations
   USE ntv_mod, ONLY : isw_ntv_mode, isw_qflux_NA, in_file_pert,     &
+       isw_m_phi_input, m_phi_input,                                &
        MtOvR, Om_tE, B_rho_L_loc, xstart_cyl, isw_ripple_solver,   &
        isw_calc_Er, isw_calc_MagDrift, species_tag_Vphi,            &
        isw_Vphi_loc, Vphi, R_Vphi, Z_Vphi, boozer_theta_Vphi,       &
-       dn_spec_ov_ds, dT_spec_ov_ds
+       dn_spec_ov_ds, dT_spec_ov_ds, has_perturbation_file
 
   ! derivative of iota for non-local NTV computations
   ! (with magnetic shear)
@@ -246,7 +247,8 @@ module neo2_ql
   ! Extra input for NTV computation
   NAMELIST /ntv_input/                                                        &
        isw_ntv_mode, isw_qflux_NA, in_file_pert, MtOvR, Om_tE, B_rho_L_loc,  &
-       isw_ripple_solver, isw_mag_shear
+       isw_ripple_solver, isw_mag_shear,                                      &
+       isw_m_phi_input, m_phi_input
 
 contains
 
@@ -660,6 +662,8 @@ subroutine main
        ! ntv_input
        CALL h5_define_group(h5_config_id, 'ntv_input', h5_config_group)
        CALL h5_add(h5_config_group, 'isw_qflux_NA', isw_qflux_NA)
+       CALL h5_add(h5_config_group, 'isw_m_phi_input', isw_m_phi_input)
+       CALL h5_add(h5_config_group, 'm_phi_input', m_phi_input)
        CALL h5_add(h5_config_group, 'MtOvR', MtOvR)
        CALL h5_add(h5_config_group, 'Om_tE', Om_tE)
        CALL h5_add(h5_config_group, 'B_rho_L_loc', B_rho_L_loc)
@@ -891,6 +895,9 @@ subroutine main
     ! ntv_input
     isw_ntv_mode = 0
     isw_qflux_NA = 0
+    in_file_pert = 'none'
+    isw_m_phi_input = 0
+    m_phi_input = 0
     MtOvR = 0.0d0
     Om_tE = 0.0d0
     B_rho_L_loc = 0.0d0
@@ -1158,10 +1165,12 @@ subroutine main
            'if [ ! -e ' // TRIM(ADJUSTL(in_file)) // ' ]; then ln -s ../' // &
            TRIM(ADJUSTL(in_file)) // ' . ; fi'
       call command_line_wrapper(cmd_line)
-      cmd_line = &
-           'if [ ! -e ' // TRIM(ADJUSTL(in_file_pert)) // ' ]; then ln -s ../' // &
-           TRIM(ADJUSTL(in_file_pert)) // ' . ; fi'
-      call command_line_wrapper(cmd_line)
+      IF (has_perturbation_file()) THEN
+        cmd_line = &
+             'if [ ! -e ' // TRIM(ADJUSTL(in_file_pert)) // ' ]; then ln -s ../' // &
+             TRIM(ADJUSTL(in_file_pert)) // ' . ; fi'
+        call command_line_wrapper(cmd_line)
+      END IF
       cmd_line = &
            'if [ ! -e neo.in ]; then ln -s ../neo.in . ; fi'
       call command_line_wrapper(cmd_line)

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -934,6 +934,14 @@ subroutine main
       write(*,*) 'Aborting...'
       stop
     end if
+
+    if (isw_qflux_NA == 1 .and. .not. has_perturbation_file()) then
+      write(*,*) 'ERROR: non-axisymmetric solve has no source.'
+      write(*,*) "  isw_qflux_NA=1 with in_file_pert='none' provides no"
+      write(*,*) '  perturbation field. Provide a perturbation file.'
+      write(*,*) 'Aborting...'
+      stop
+    end if
   end subroutine check
 
 

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -952,11 +952,17 @@ subroutine main
     end if
 
     if (isw_qflux_NA == 1 .and. .not. has_perturbation_file()) then
-      write(*,*) 'ERROR: non-axisymmetric solve has no source.'
-      write(*,*) "  isw_qflux_NA=1 with in_file_pert='none' provides no"
-      write(*,*) '  perturbation field. Provide a perturbation file.'
-      write(*,*) 'Aborting...'
-      stop
+      if (isw_hel_drive == 0 .or. &
+          (hel_phim_re == 0.0d0 .and. hel_phim_im == 0.0d0 .and. &
+           hel_brad_re == 0.0d0 .and. hel_brad_im == 0.0d0)) then
+        write(*,*) 'ERROR: non-axisymmetric solve has no source.'
+        write(*,*) "  isw_qflux_NA=1 with in_file_pert='none' provides no"
+        write(*,*) '  perturbation field, and the helical drive is off or zero.'
+        write(*,*) '  Provide a perturbation file, or set isw_hel_drive with a'
+        write(*,*) '  non-zero hel_phim/hel_brad amplitude.'
+        write(*,*) 'Aborting...'
+        stop
+      end if
     end if
   end subroutine check
 

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -65,7 +65,9 @@ module neo2_ql
        MtOvR, Om_tE, B_rho_L_loc, xstart_cyl, isw_ripple_solver,   &
        isw_calc_Er, isw_calc_MagDrift, species_tag_Vphi,            &
        isw_Vphi_loc, Vphi, R_Vphi, Z_Vphi, boozer_theta_Vphi,       &
-       dn_spec_ov_ds, dT_spec_ov_ds, has_perturbation_file
+       dn_spec_ov_ds, dT_spec_ov_ds,                                &
+       isw_hel_drive, m_theta_hel, hel_brad_re, hel_brad_im,        &
+       hel_phim_re, hel_phim_im, has_perturbation_file
 
   ! derivative of iota for non-local NTV computations
   ! (with magnetic shear)
@@ -248,7 +250,9 @@ module neo2_ql
   NAMELIST /ntv_input/                                                        &
        isw_ntv_mode, isw_qflux_NA, in_file_pert, MtOvR, Om_tE, B_rho_L_loc,  &
        isw_ripple_solver, isw_mag_shear,                                      &
-       isw_m_phi_input, m_phi_input
+       isw_m_phi_input, m_phi_input,                                          &
+       isw_hel_drive, m_theta_hel, hel_brad_re, hel_brad_im,                  &
+       hel_phim_re, hel_phim_im
 
 contains
 
@@ -669,6 +673,12 @@ subroutine main
        CALL h5_add(h5_config_group, 'B_rho_L_loc', B_rho_L_loc)
        CALL h5_add(h5_config_group, 'isw_ripple_solver', isw_ripple_solver)
        CALL h5_add(h5_config_group, 'isw_mag_shear', isw_mag_shear)
+       CALL h5_add(h5_config_group, 'isw_hel_drive', isw_hel_drive)
+       CALL h5_add(h5_config_group, 'm_theta_hel', m_theta_hel)
+       CALL h5_add(h5_config_group, 'hel_brad_re', hel_brad_re)
+       CALL h5_add(h5_config_group, 'hel_brad_im', hel_brad_im)
+       CALL h5_add(h5_config_group, 'hel_phim_re', hel_phim_re)
+       CALL h5_add(h5_config_group, 'hel_phim_im', hel_phim_im)
        CALL h5_close_group(h5_config_group)
 
        CALL h5_close(h5_config_id)
@@ -903,6 +913,12 @@ subroutine main
     B_rho_L_loc = 0.0d0
     isw_ripple_solver = 1
     isw_mag_shear = 0
+    isw_hel_drive = 0
+    m_theta_hel = 0
+    hel_brad_re = 0.0d0
+    hel_brad_im = 0.0d0
+    hel_phim_re = 0.0d0
+    hel_phim_im = 0.0d0
     !! End Modification by Andreas F. Martitsch (14.07.2015)
 
     use_fpol = .false. ! to switch off some features, which are untested with neo-2

--- a/NEO-2-QL/neo_magfie_perturbation.f90
+++ b/NEO-2-QL/neo_magfie_perturbation.f90
@@ -15,7 +15,8 @@ MODULE neo_magfie_perturbation
   USE partpa_mod,  ONLY : bmod0
   !! Modification by Andreas F. Martitsch (17.07.2014)
   ! Extra input for NTV computations
-  USE ntv_mod, ONLY : in_file_pert, m_phi
+  USE ntv_mod, ONLY : in_file_pert, isw_m_phi_input, m_phi_input, m_phi, &
+       has_perturbation_file
   !! End Modification by Andreas F. Martitsch (17.07.2014)
   ! coordinates of starting point
   USE mag_interface_mod, ONLY : boozer_s, boozer_theta_beg,&
@@ -65,6 +66,7 @@ MODULE neo_magfie_perturbation
   PRIVATE r_m_pert, r_mhalf_pert, sp_index_pert
   REAL(kind=dp), DIMENSION(:),   ALLOCATABLE :: r_m_pert, r_mhalf_pert
   INTEGER(I4B),  DIMENSION(:),   ALLOCATABLE :: sp_index_pert
+  LOGICAL :: perturbation_initialized = .FALSE.
 
   PUBLIC neo_magfie_pert
   PRIVATE neo_magfie_pert_a, neo_magfie_pert_b
@@ -94,6 +96,18 @@ CONTAINS
     ! open Boozer file and read first quantities
     r_un=27052014
     in_file_pert=TRIM(ADJUSTL(in_file_pert))
+
+    IF (.NOT. has_perturbation_file()) THEN
+       IF (isw_m_phi_input .EQ. 0) THEN
+          STOP "in_file_pert='none' requires isw_m_phi_input=1"
+       END IF
+       m_phi = m_phi_input
+       mnmax_pert = 0
+       ns_pert = 0
+       perturbation_initialized = .TRUE.
+       RETURN
+    END IF
+
     OPEN(unit=r_un,file=in_file_pert,status='old',form='formatted')
 
     IF (inp_swi == INP_SWI_TOK_CIRC) THEN ! NEW IPP TOKAMAK
@@ -206,8 +220,10 @@ CONTAINS
        PRINT *,'FATAL: There is yet no other Laboratory for the perturbed field defined!'
        STOP
     END IF
+    IF (isw_m_phi_input .NE. 0) m_phi = m_phi_input
     ! close Boozer file
     CLOSE (unit=r_un)
+    perturbation_initialized = .TRUE.
     RETURN
   END SUBROUTINE neo_read_pert
 
@@ -306,9 +322,9 @@ CONTAINS
 
     ! read Boozer file and prepare spline routines (1st call)
 
-    IF (.NOT. ALLOCATED(es_pert)) THEN
+    IF (.NOT. perturbation_initialized) THEN
        CALL neo_read_pert()
-       CALL neo_init_spline_pert()
+       IF (mnmax_pert .GT. 0) CALL neo_init_spline_pert()
     END IF
 
     ! direct summation of Fourier components
@@ -410,9 +426,9 @@ CONTAINS
 
     ! read Boozer file and prepare spline routines (1st call)
 
-    IF (.NOT. ALLOCATED(es_pert)) THEN
+    IF (.NOT. perturbation_initialized) THEN
        CALL neo_read_pert()
-       CALL neo_init_spline_pert()
+       IF (mnmax_pert .GT. 0) CALL neo_init_spline_pert()
     END IF
 
     ! direct summation of Fourier components

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -33,6 +33,10 @@ MODULE ntv_mod
   INTEGER, PUBLIC :: isw_ripple_solver
   !> name of perturbation file
   CHARACTER(len=100), PUBLIC :: in_file_pert
+  !> switch: use m_phi_input instead of taking m_phi from the perturbation file
+  INTEGER, PUBLIC :: isw_m_phi_input
+  !> toroidal mode number used when isw_m_phi_input is enabled
+  INTEGER, PUBLIC :: m_phi_input
   !> toroidal mach number over R_major (Mt/R).
   !> Only used for legacy single-species NTV output (isw_calc_Er=0).
   !> Ignored when isw_calc_Er >= 1; the multispecies code uses Om_tE instead.
@@ -193,7 +197,21 @@ MODULE ntv_mod
      MODULE PROCEDURE compute_TphiNA_a
   END INTERFACE compute_TphiNA
 
+  PUBLIC has_perturbation_file
+
 CONTAINS
+
+  LOGICAL FUNCTION has_perturbation_file()
+    CHARACTER(len=100) :: file_name
+
+    file_name = ADJUSTL(in_file_pert)
+    has_perturbation_file = LEN_TRIM(file_name) .GT. 0
+    IF (has_perturbation_file) THEN
+       IF (TRIM(file_name) .EQ. 'none') has_perturbation_file = .FALSE.
+       IF (TRIM(file_name) .EQ. 'None') has_perturbation_file = .FALSE.
+       IF (TRIM(file_name) .EQ. 'NONE') has_perturbation_file = .FALSE.
+    END IF
+  END FUNCTION has_perturbation_file
 
   SUBROUTINE compute_Dij_norm_a(qflux_NA_in,qflux_AX_in,Dij_NA,Dij_AX)
 

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -209,9 +209,19 @@ MODULE ntv_mod
      MODULE PROCEDURE compute_TphiNA_a
   END INTERFACE compute_TphiNA
 
-  PUBLIC has_perturbation_file
+  PUBLIC has_perturbation_file, has_helical_drive_source
 
 CONTAINS
+
+  LOGICAL FUNCTION has_helical_drive_source()
+    has_helical_drive_source = .FALSE.
+    IF (isw_hel_drive .EQ. 0) RETURN
+
+    IF (hel_brad_re .NE. 0.0_dp) has_helical_drive_source = .TRUE.
+    IF (hel_brad_im .NE. 0.0_dp) has_helical_drive_source = .TRUE.
+    IF (hel_phim_re .NE. 0.0_dp) has_helical_drive_source = .TRUE.
+    IF (hel_phim_im .NE. 0.0_dp) has_helical_drive_source = .TRUE.
+  END FUNCTION has_helical_drive_source
 
   LOGICAL FUNCTION has_perturbation_file()
     CHARACTER(len=100) :: file_name

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -47,6 +47,18 @@ MODULE ntv_mod
   REAL(kind=dp), PUBLIC :: Om_tE
   !> Larmor radius associated with $B_{00}^{Booz}$ (rho_L_loc) times B
   REAL(kind=dp), PUBLIC :: B_rho_L_loc
+  !> switch: turn on(=1)/off(=0) the single-helicity misalignment drive
+  !> (additional RHS of the non-axisymmetric equation set)
+  INTEGER, PUBLIC :: isw_hel_drive
+  !> poloidal mode number m of the misalignment-drive harmonic
+  !> (toroidal mode number n is m_phi from the file or m_phi_input)
+  INTEGER, PUBLIC :: m_theta_hel
+  !> complex amplitude (delta B^s/B_0^phi)_mn of the radial corrugation,
+  !> dimensionless flux-function amplitude
+  REAL(kind=dp), PUBLIC :: hel_brad_re, hel_brad_im
+  !> complex amplitude Phi_mn of the electrostatic perturbation harmonic
+  !> in statvolt
+  REAL(kind=dp), PUBLIC :: hel_phim_re, hel_phim_im
 
   ! ADDITIONAL INPUT FOR MULTI-SPECIES COMPUTATIONS (neo2.in)
 

--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -17,7 +17,7 @@ subroutine ripple_solver_ArnoldiO2( &
     use collisionality_mod, only: collpar, conl_over_mfp, isw_lorentz, &
                                   isw_energy, isw_integral, isw_axisymm, & !<-in Winny
                                   isw_momentum, nvel, num_spec, lsw_multispecies, &
-                                  T_spec, m_spec
+                                  T_spec, m_spec, z_spec
 ! collpar - the same as $\kappa$ - inverse mean-free path times 4
   !! Modifications by Andreas F. Martitsch (01.04.2015)
     !
@@ -77,7 +77,9 @@ subroutine ripple_solver_ArnoldiO2( &
     use ntv_mod, only: isw_qflux_NA, MtOvR, Om_tE, B_rho_L_loc, &
                        m_phi, qflux_symm, eps_M_2_val, av_gphph_val, av_inv_bhat_val, &
                        qflux_symm_allspec, qflux_ntv_allspec, &
-                       MtOvR_spec, isw_calc_Er, B_rho_L_loc_spec, isw_calc_MagDrift
+                       MtOvR_spec, isw_calc_Er, B_rho_L_loc_spec, isw_calc_MagDrift, &
+                       isw_hel_drive, m_theta_hel, hel_brad_re, hel_brad_im, &
+                       hel_phim_re, hel_phim_im, clight_hel => c, echarge_hel => e
     use ntv_mod, only: get_Er, get_B_rho_L_loc
     use er_rotation_mod, only: Om_tE_to_MtOvR_spec
   !! End Modification by Andreas F. Martitsch (14.07.2015)
@@ -218,6 +220,12 @@ subroutine ripple_solver_ArnoldiO2( &
     complex(dp), dimension(:, :), allocatable :: q_rip_1
     complex(dp), dimension(:, :), allocatable :: q_rip_incompress
     complex(dp), dimension(:, :), allocatable :: q_rip_parflow
+    ! Single-helicity misalignment drive: band profiles along the field line
+    ! (q_hel_b: vpar corrugation piece, q_hel_e: ExB piece)
+    complex(dp), dimension(:, :), allocatable :: q_hel_b, q_hel_e
+    complex(dp) :: amp_hel_b, amp_hel_e, hel_phase, hel_phase_fac
+    real(dp) :: vt_hel, rho_hel
+    logical :: hel_drive_active
     real(dp), dimension(:, :, :), allocatable :: rhs_mat_energ
     real(dp), dimension(:, :, :), allocatable :: rhs_mat_energ2     !NTV
     real(dp), dimension(:, :, :), allocatable :: pleg_bra, pleg_ket
@@ -283,6 +291,8 @@ subroutine ripple_solver_ArnoldiO2( &
     integer :: i_ctr = 0, uw, uw_new
     logical :: lsw_debug_distfun = .FALSE.
     logical :: addboucol = .false.
+
+    hel_drive_active = .FALSE.
 
     ! multi-species part - MPI rank determines species
     ispec = mpro%getRank()
@@ -923,6 +933,10 @@ subroutine ripple_solver_ArnoldiO2( &
     allocate (q_rip_1(npart + 2, ibeg:iend))
     allocate (q_rip_incompress(npart + 2, ibeg:iend))
     allocate (q_rip_parflow(npart + 2, ibeg:iend))
+    allocate (q_hel_b(npart + 2, ibeg:iend))
+    allocate (q_hel_e(npart + 2, ibeg:iend))
+    q_hel_b = (0.d0, 0.d0)
+    q_hel_e = (0.d0, 0.d0)
     allocate (convol_flux(npart + 1, ibeg:iend), convol_curr(npart + 1, ibeg:iend))
     allocate (convol_flux_0(npart + 1, ibeg:iend))
     allocate (ind_start(ibeg:iend))
@@ -1008,6 +1022,7 @@ subroutine ripple_solver_ArnoldiO2( &
         deallocate (fun_coef, ttmp_mat)
         deallocate (rhs_mat_energ2)        !NTV
         deallocate (q_rip, q_rip_1, q_rip_incompress, q_rip_parflow)
+        deallocate (q_hel_b, q_hel_e)
         deallocate (convol_flux, convol_curr, convol_flux_0)
         deallocate (pleg_bra, pleg_ket, scalprod_pleg)
         write (*, *) 'ERROR: maxval(phi_divide) > 1, returning.'
@@ -3180,6 +3195,45 @@ subroutine ripple_solver_ArnoldiO2( &
         q_rip(:, istep, 2) = -2.d0*q_rip(:, istep, 2)*bnoverb0(istep)
     end do
 
+    ! Single-helicity misalignment drive: fill the band profiles along the
+    ! field line. Amplitudes and band integrals follow the CAS-checked
+    ! derivation referenced in the pull request:
+    !   vpar corrugation piece: band source cB (eta_k - eta_{k-1})/rho_alpha,
+    !     sigma-odd, velocity weights a3m (A1 channel) and x^2 (A2 channel);
+    !   ExB piece: band source 2 (lambda_{k-1} - lambda_k) vE^s_m /
+    !     (Bhat h^phi vT rho_alpha), sigma-even, velocity weights x^-1
+    !     (A1 channel) and a1m (A2 channel);
+    !   vE^s_m z e bmod0/(2 T c) reduces to the bmod0-free hat form used
+    !     for amp_hel_e below.
+    if (isw_hel_drive .ne. 0) then
+        hel_drive_active = .TRUE.
+        hel_phase_fac = imun*(DBLE(m_theta_hel)*aiota + DBLE(m_phi))
+        vt_hel = SQRT(2.d0*T_spec(ispec)/m_spec(ispec))
+        rho_hel = vt_hel*m_spec(ispec)*clight_hel &
+                  /(z_spec(ispec)*echarge_hel*(bmod0*1.0d4))
+        amp_hel_b = CMPLX(hel_brad_re, hel_brad_im, kind=dp)/rho_hel
+        amp_hel_e = imun*CMPLX(hel_phim_re, hel_phim_im, kind=dp) &
+                    *z_spec(ispec)*echarge_hel/(2.d0*T_spec(ispec)) &
+                    *(DBLE(m_phi)*bcovar_theta_hat - DBLE(m_theta_hel)*bcovar_phi_hat) &
+                    /(boozer_psi_pr_hat*denomjac)
+        do istep = ibeg, iend
+            npassing = npl(istep)
+            hel_phase = EXP(hel_phase_fac*phi_mfl(istep))
+            q_hel_b(:, istep) = (0.d0, 0.d0)
+            q_hel_e(:, istep) = (0.d0, 0.d0)
+            q_hel_b(1:npassing, istep) = amp_hel_b*hel_phase &
+                *(eta(1:npassing) - eta(0:npassing - 1))
+            q_hel_b(npassing + 1, istep) = amp_hel_b*hel_phase &
+                *(1.d0/bhat_mfl(istep) - eta(npassing))
+            q_hel_e(1:npassing, istep) = amp_hel_e*hel_phase &
+                *2.d0*(alambd(0:npassing - 1, istep) - alambd(1:npassing, istep)) &
+                /(bhat_mfl(istep)*h_phi_mfl(istep))
+            q_hel_e(npassing + 1, istep) = amp_hel_e*hel_phase &
+                *2.d0*alambd(npassing, istep) &
+                /(bhat_mfl(istep)*h_phi_mfl(istep))
+        end do
+    end if
+
     if (nobounceaver) then
     !! Modifications by Andreas F. Martitsch (18.08.2014)
         ! derivative along the periodic Boozer angle theta has
@@ -3312,6 +3366,7 @@ subroutine ripple_solver_ArnoldiO2( &
     deallocate (enu_coef2, dellampow2, rhs_mat_energ2)
     deallocate (npl, rhs_mat_fzero, rhs_mat_lorentz, rhs_mat_energ, q_rip, q_rip_1)
     deallocate (q_rip_incompress, q_rip_parflow)
+    deallocate (q_hel_b, q_hel_e)
     deallocate (fun_coef, ttmp_mat)
     deallocate (convol_flux, convol_curr, ind_start, convol_flux_0)
     deallocate (delt_pos, delt_neg, fact_pos_b, fact_neg_b, fact_pos_e, fact_neg_e)
@@ -4189,7 +4244,134 @@ CONTAINS
             end do
         end do
 
+        if (hel_drive_active .and. iplot .ne. 1) then
+            call add_hel_source(q_hel_b, asource(0:lag, 2), 1, -1)
+            call add_hel_source(q_hel_b, asource_hel(0:lag, 2), 3, -1)
+            call add_hel_source(q_hel_e, asource_hel(0:lag, 1), 1, 1)
+            call add_hel_source(q_hel_e, asource(0:lag, 1), 3, 1)
+        end if
+
     end subroutine source_flux
+
+!------------------------------------------------------------------------
+    subroutine add_hel_source(q_hel, amom, lcol, isig)
+
+! Adds one misalignment-drive piece (band profile q_hel, velocity moments
+! amom) to source_vector column lcol, following the integration-scheme
+! structure of the standard drives assembled above. isig = +1 for
+! sigma-even pieces (sign pattern of columns 1 and 3), isig = -1 for
+! sigma-odd pieces (sign pattern of column 2).
+
+        complex(dp), dimension(:, ibeg:), intent(in) :: q_hel
+        real(dp), dimension(0:), intent(in) :: amom
+        integer, intent(in) :: lcol, isig
+
+        integer :: is, mh, kh, kh_prev, np, np_prev, np_next
+        real(dp) :: sg
+
+        sg = DBLE(isig)
+
+        do is = ibeg, iend
+            np = npl(is)
+            do mh = 0, lag
+                kh = ind_start(is) + 2*(np + 1)*mh
+
+                if (is .GT. ibeg) then
+                    np_prev = npl(is - 1)
+                    kh_prev = ind_start(is - 1) + 2*(np_prev + 1)*mh
+                    if (MOD(is - ibeg, 2) .EQ. 1) then
+                        np_next = npl(is + 1)
+                        source_vector(kh + 1:kh + np + 1, lcol) &
+                            = source_vector(kh + 1:kh + np + 1, lcol) &
+                              + amom(mh)/1.5d0*q_hel(1:np + 1, is)*fact_pos_e(is)
+                        source_vector(kh + 1:kh + np_prev + 1, lcol) &
+                            = source_vector(kh + 1:kh + np_prev + 1, lcol) &
+                              + amom(mh)/2.4d0*q_hel(1:np_prev + 1, is - 1)*fact_pos_b(is - 1)
+                        source_vector(kh + 1:kh + np_next + 1, lcol) &
+                            = source_vector(kh + 1:kh + np_next + 1, lcol) &
+                              - amom(mh)/12d0*q_hel(1:np_next + 1, is + 1)*fact_pos_e(is + 1)
+                    else
+                        np_next = npl(is - 2)
+                        source_vector(kh + 1:kh + np + 1, lcol) &
+                            = source_vector(kh + 1:kh + np + 1, lcol) &
+                              + amom(mh)/2.4d0*q_hel(1:np + 1, is)*fact_pos_e(is)
+                        if (np_prev .LE. np) then
+                            source_vector(kh + 1:kh + np_prev + 1, lcol) &
+                                = source_vector(kh + 1:kh + np_prev + 1, lcol) &
+                                  + amom(mh)/1.5d0*q_hel(1:np_prev + 1, is - 1)*fact_pos_b(is - 1)
+                        else
+                            source_vector(kh + 1:kh + np + 1, lcol) &
+                                = source_vector(kh + 1:kh + np + 1, lcol) &
+                                  + amom(mh)/1.5d0*q_hel(1:np + 1, is - 1)*fact_pos_b(is - 1)
+                            source_vector(kh_prev + np_prev + 2, lcol) &
+                                = source_vector(kh_prev + np_prev + 2, lcol) &
+                                  + amom(mh)/1.5d0*q_hel(np_prev + 1, is - 1)*fact_pos_b(is - 1)
+                        end if
+                        if (np_next .LE. np) then
+                            source_vector(kh + 1:kh + np_next + 1, lcol) &
+                                = source_vector(kh + 1:kh + np_next + 1, lcol) &
+                                  - amom(mh)/12d0*q_hel(1:np_next + 1, is - 2)*fact_pos_b(is - 2)
+                        else
+                            source_vector(kh + 1:kh + np + 1, lcol) &
+                                = source_vector(kh + 1:kh + np + 1, lcol) &
+                                  - amom(mh)/12d0*q_hel(1:np + 1, is - 2)*fact_pos_b(is - 2)
+                            source_vector(kh_prev + np_prev + 2, lcol) &
+                                = source_vector(kh_prev + np_prev + 2, lcol) &
+                                  - amom(mh)/12d0*q_hel(np_next + 1, is - 2)*fact_pos_b(is - 2)
+                        end if
+                    end if
+                end if
+
+                if (is .LT. iend) then
+                    np_prev = npl(is + 1)
+                    kh_prev = ind_start(is + 1) + 2*(np_prev + 1)*mh
+                    if (MOD(is - ibeg, 2) .EQ. 1) then
+                        np_next = npl(is - 1)
+                        source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                            = source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                              + sg*amom(mh)/1.5d0*q_hel(np + 1:1:-1, is)*fact_neg_e(is)
+                        source_vector(kh + 2*np + 2 - np_prev:kh + 2*np + 2, lcol) &
+                            = source_vector(kh + 2*np + 2 - np_prev:kh + 2*np + 2, lcol) &
+                              + sg*amom(mh)/2.4d0*q_hel(np_prev + 1:1:-1, is + 1)*fact_neg_b(is + 1)
+                        source_vector(kh + 2*np + 2 - np_next:kh + 2*np + 2, lcol) &
+                            = source_vector(kh + 2*np + 2 - np_next:kh + 2*np + 2, lcol) &
+                              - sg*amom(mh)/12d0*q_hel(np_next + 1:1:-1, is - 1)*fact_neg_e(is - 1)
+                    else
+                        np_next = npl(is + 2)
+                        source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                            = source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                              + sg*amom(mh)/2.4d0*q_hel(np + 1:1:-1, is)*fact_neg_e(is)
+                        if (np_prev .LE. np) then
+                            source_vector(kh + 2*np + 2 - np_prev:kh + 2*np + 2, lcol) &
+                                = source_vector(kh + 2*np + 2 - np_prev:kh + 2*np + 2, lcol) &
+                                  + sg*amom(mh)/1.5d0*q_hel(np_prev + 1:1:-1, is + 1)*fact_neg_b(is + 1)
+                        else
+                            source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                                = source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                                  + sg*amom(mh)/1.5d0*q_hel(np + 1:1:-1, is + 1)*fact_neg_b(is + 1)
+                            source_vector(kh_prev + np_prev + 1, lcol) &
+                                = source_vector(kh_prev + np_prev + 1, lcol) &
+                                  + sg*amom(mh)/1.5d0*q_hel(np_prev + 1, is + 1)*fact_neg_b(is + 1)
+                        end if
+                        if (np_next .LE. np) then
+                            source_vector(kh + 2*np + 2 - np_next:kh + 2*np + 2, lcol) &
+                                = source_vector(kh + 2*np + 2 - np_next:kh + 2*np + 2, lcol) &
+                                  - sg*amom(mh)/12d0*q_hel(np_next + 1:1:-1, is + 2)*fact_neg_b(is + 2)
+                        else
+                            source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                                = source_vector(kh + np + 2:kh + 2*np + 2, lcol) &
+                                  - sg*amom(mh)/12d0*q_hel(np + 1:1:-1, is + 2)*fact_neg_b(is + 2)
+                            source_vector(kh_prev + np_prev + 1, lcol) &
+                                = source_vector(kh_prev + np_prev + 1, lcol) &
+                                  - sg*amom(mh)/12d0*q_hel(np_next + 1, is + 2)*fact_neg_b(is + 2)
+                        end if
+                    end if
+                end if
+
+            end do
+        end do
+
+    end subroutine add_hel_source
 
 !------------------------------------------------------------------------
     subroutine add_f01_source

--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -3206,6 +3206,22 @@ subroutine ripple_solver_ArnoldiO2( &
     !   vE^s_m z e bmod0/(2 T c) reduces to the bmod0-free hat form used
     !     for amp_hel_e below.
     if (isw_hel_drive .ne. 0) then
+        if (.not. allocated(asource_hel)) then
+            stop 'isw_hel_drive requires quadrature collision moments '// &
+                 '(incompatible with precomputed matrix elements)'
+        end if
+        if (isw_relativistic .ne. 0) then
+            stop 'isw_hel_drive: relativistic drive moments not validated'
+        end if
+        if (iplot .eq. 1) then
+            stop 'isw_hel_drive: reconstruction mode not supported'
+        end if
+        if (T_spec(ispec) .le. 0.d0 .or. m_spec(ispec) .le. 0.d0) then
+            stop 'isw_hel_drive: invalid species temperature or mass'
+        end if
+        if (z_spec(ispec) .eq. 0.d0) then
+            stop 'isw_hel_drive: invalid species charge number'
+        end if
         hel_drive_active = .TRUE.
         hel_phase_fac = imun*(DBLE(m_theta_hel)*aiota + DBLE(m_phi))
         vt_hel = SQRT(2.d0*T_spec(ispec)/m_spec(ispec))

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -76,6 +76,29 @@ set_tests_properties(ntv_hel_drive_input_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_ntv_source_guard test_ntv_source_guard.f90)
+target_link_libraries(test_ntv_source_guard neo2_ql)
+
+add_test(NAME ntv_zero_source_guard_test
+         COMMAND test_ntv_source_guard zero
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(ntv_zero_source_guard_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "ERROR: non-axisymmetric solve has no source."
+    FAIL_REGULAR_EXPRESSION "FAIL;NaN;zhseqr;returned from rejected source"
+    TIMEOUT 5
+)
+
+add_test(NAME ntv_driven_source_guard_test
+         COMMAND test_ntv_source_guard driven
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(ntv_driven_source_guard_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "Driven source accepted!"
+    FAIL_REGULAR_EXPRESSION "FAIL;NaN;zhseqr;non-axisymmetric solve has no source"
+    TIMEOUT 5
+)
+
 add_executable(test_spline_sparse_assembly test_spline_sparse_assembly.f90)
 target_link_libraries(test_spline_sparse_assembly common)
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -112,6 +112,19 @@ set_tests_properties(phi_divider_parity_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_join_failure_diagnostic test_join_failure_diagnostic.f90)
+target_link_libraries(test_join_failure_diagnostic neo2_ql)
+
+add_test(NAME join_failure_diagnostic_test
+         COMMAND test_join_failure_diagnostic
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(join_failure_diagnostic_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "join_ripples: DGBSV info=2"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_spline_sparse_assembly test_spline_sparse_assembly.f90)
 target_link_libraries(test_spline_sparse_assembly common)
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -99,6 +99,19 @@ set_tests_properties(ntv_driven_source_guard_test PROPERTIES
     TIMEOUT 5
 )
 
+add_executable(test_phi_divider_parity test_phi_divider_parity.f90)
+target_link_libraries(test_phi_divider_parity common)
+
+add_test(NAME phi_divider_parity_test
+         COMMAND test_phi_divider_parity
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(phi_divider_parity_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_spline_sparse_assembly test_spline_sparse_assembly.f90)
 target_link_libraries(test_spline_sparse_assembly common)
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -50,6 +50,19 @@ set_tests_properties(er_rotation_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_ntv_perturbation_input test_ntv_perturbation_input.f90)
+target_link_libraries(test_ntv_perturbation_input neo2_ql)
+
+add_test(NAME ntv_perturbation_input_test
+         COMMAND test_ntv_perturbation_input
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(ntv_perturbation_input_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_spline_sparse_assembly test_spline_sparse_assembly.f90)
 target_link_libraries(test_spline_sparse_assembly common)
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -63,6 +63,19 @@ set_tests_properties(ntv_perturbation_input_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_ntv_hel_drive_input test_ntv_hel_drive_input.f90)
+target_link_libraries(test_ntv_hel_drive_input neo2_ql)
+
+add_test(NAME ntv_hel_drive_input_test
+         COMMAND test_ntv_hel_drive_input
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(ntv_hel_drive_input_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_spline_sparse_assembly test_spline_sparse_assembly.f90)
 target_link_libraries(test_spline_sparse_assembly common)
 

--- a/TEST/test_join_failure_diagnostic.f90
+++ b/TEST/test_join_failure_diagnostic.f90
@@ -1,0 +1,17 @@
+program test_join_failure_diagnostic
+    use join_diagnostics_mod, only: report_join_failure
+    use lapack_band, only: gbsv
+    implicit none
+
+    real(kind(1.0d0)) :: matrix(2, 2), rhs(2, 1)
+    integer :: info, ierr, pivot(2)
+
+    matrix = reshape([1.0d0, 2.0d0, 2.0d0, 4.0d0], shape(matrix))
+    rhs(:, 1) = [1.0d0, 2.0d0]
+    call gbsv(2, 2, matrix, pivot, rhs, info)
+
+    if (info /= 2) error stop 'FAIL: singular solve did not return pivot 2'
+    call report_join_failure(2, info, [10, 20], [21, 30], 2, 2, &
+        matrix, rhs, ierr)
+    if (ierr /= 2) error stop 'FAIL: join stage was not retained'
+end program test_join_failure_diagnostic

--- a/TEST/test_ntv_hel_drive_input.f90
+++ b/TEST/test_ntv_hel_drive_input.f90
@@ -1,0 +1,52 @@
+program test_ntv_hel_drive_input
+    use nrtype, only: dp
+    use ntv_mod, only: isw_hel_drive, hel_brad_re, hel_brad_im, &
+        hel_phim_re, hel_phim_im, has_helical_drive_source
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call set_drive(0, 1.0_dp, 0.0_dp, 0.0_dp, 0.0_dp)
+    call expect_source(.false., failures)
+
+    call set_drive(1, 0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp)
+    call expect_source(.false., failures)
+
+    call set_drive(1, 1.0e-3_dp, 0.0_dp, 0.0_dp, 0.0_dp)
+    call expect_source(.true., failures)
+
+    call set_drive(1, 0.0_dp, 0.0_dp, 0.0_dp, -1.0_dp)
+    call expect_source(.true., failures)
+
+    if (failures == 0) then
+        print *, 'All tests passed!'
+    else
+        error stop 'helical-drive source detection failed'
+    end if
+
+contains
+
+    subroutine set_drive(switch, brad_re, brad_im, phim_re, phim_im)
+        integer, intent(in) :: switch
+        real(dp), intent(in) :: brad_re, brad_im, phim_re, phim_im
+
+        isw_hel_drive = switch
+        hel_brad_re = brad_re
+        hel_brad_im = brad_im
+        hel_phim_re = phim_re
+        hel_phim_im = phim_im
+    end subroutine set_drive
+
+    subroutine expect_source(expected, status)
+        logical, intent(in) :: expected
+        integer, intent(inout) :: status
+
+        if (has_helical_drive_source() .neqv. expected) then
+            print *, 'FAIL: unexpected helical-drive source state'
+            status = status + 1
+        end if
+    end subroutine expect_source
+
+end program test_ntv_hel_drive_input

--- a/TEST/test_ntv_perturbation_input.f90
+++ b/TEST/test_ntv_perturbation_input.f90
@@ -1,0 +1,63 @@
+program test_ntv_perturbation_input
+  use ntv_mod, only: in_file_pert, isw_m_phi_input, m_phi_input, m_phi, &
+                     has_perturbation_file
+  use neo_magfie_perturbation, only: neo_read_pert
+  implicit none
+
+  integer :: test_status
+
+  test_status = 0
+
+  call test_none_file(test_status)
+  call test_file_flag(test_status)
+
+  if (test_status == 0) then
+     print *, "All tests passed!"
+  else
+     print *, "Some tests failed. Status:", test_status
+     error stop
+  end if
+
+contains
+
+  subroutine test_none_file(status)
+    integer, intent(inout) :: status
+
+    in_file_pert = 'none'
+    isw_m_phi_input = 1
+    m_phi_input = -1
+    m_phi = 0
+
+    call neo_read_pert()
+
+    if (has_perturbation_file()) then
+       print *, "FAIL: none should disable perturbation-file input"
+       status = status + 1
+    else
+       print *, "PASS: none disables perturbation-file input"
+    end if
+
+    if (m_phi /= -1) then
+       print *, "FAIL: prescribed m_phi was not used"
+       print *, "  Expected:", -1
+       print *, "  Got:", m_phi
+       status = status + 1
+    else
+       print *, "PASS: prescribed m_phi was used"
+    end if
+  end subroutine test_none_file
+
+  subroutine test_file_flag(status)
+    integer, intent(inout) :: status
+
+    in_file_pert = 'perturbation.bc'
+
+    if (has_perturbation_file()) then
+       print *, "PASS: regular file name enables perturbation-file input"
+    else
+       print *, "FAIL: regular file name should enable perturbation-file input"
+       status = status + 1
+    end if
+  end subroutine test_file_flag
+
+end program test_ntv_perturbation_input

--- a/TEST/test_ntv_source_guard.f90
+++ b/TEST/test_ntv_source_guard.f90
@@ -1,0 +1,32 @@
+program test_ntv_source_guard
+    use neo2_ql, only: init, check
+    use ntv_mod, only: isw_qflux_NA, in_file_pert, isw_hel_drive, &
+        hel_brad_re, hel_brad_im, hel_phim_re, hel_phim_im
+    implicit none
+
+    character(len=16) :: test_case
+
+    call get_command_argument(1, test_case)
+    call init()
+
+    isw_qflux_NA = 1
+    in_file_pert = 'none'
+    isw_hel_drive = 0
+    hel_brad_re = 0.0d0
+    hel_brad_im = 0.0d0
+    hel_phim_re = 0.0d0
+    hel_phim_im = 0.0d0
+
+    select case (trim(test_case))
+    case ('zero')
+        call check()
+        error stop 'returned from rejected source'
+    case ('driven')
+        isw_hel_drive = 1
+        hel_phim_re = 1.0d0
+        call check()
+        print *, 'Driven source accepted!'
+    case default
+        error stop 'FAIL: unknown test case'
+    end select
+end program test_ntv_source_guard

--- a/TEST/test_phi_divider_parity.f90
+++ b/TEST/test_phi_divider_parity.f90
@@ -1,0 +1,73 @@
+program test_phi_divider_parity
+    use device_mod, only: fieldpropagator
+    use flint_mod, only: phi_divide, phi_divider, phiarr
+    implicit none
+
+    integer, parameter :: ninterval = 4
+    integer :: forward_map(0:ninterval), reverse_map(0:ninterval)
+    real(kind(1.0d0)) :: forward_nodes(0:ninterval), reverse_nodes(0:ninterval)
+    integer :: i, failures
+
+    failures = 0
+    call refined_node_map([2, 1, 2, 2], forward_map, forward_nodes)
+    call refined_node_map([2, 2, 1, 2], reverse_map, reverse_nodes)
+
+    do i = 0, ninterval
+        if (forward_nodes(i) /= real(i, kind(1.0d0)) .or. &
+            reverse_nodes(i) /= real(i, kind(1.0d0))) then
+            print *, 'FAIL: refinement dropped an original grid point'
+            failures = failures + 1
+        end if
+        if (reverse_map(i) /= forward_map(ninterval) - forward_map(ninterval - i)) then
+            print *, 'FAIL: reversed refinement changed the mapped grid'
+            failures = failures + 1
+        end if
+    end do
+
+    if (any(forward_map(1:) <= forward_map(:ninterval - 1)) .or. &
+        any(reverse_map(1:) <= reverse_map(:ninterval - 1))) then
+        print *, 'FAIL: refinement did not preserve grid ordering'
+        failures = failures + 1
+    end if
+
+    if (mod(forward_map(ninterval), 2) /= 0) then
+        print *, 'FAIL: refinement made the final Runge-Kutta point a half step'
+        failures = failures + 1
+    end if
+
+    if (failures == 0) then
+        print *, 'All tests passed!'
+    else
+        error stop 'phi-divider parity contract failed'
+    end if
+
+contains
+
+    subroutine refined_node_map(divisions, node_map, node_values)
+        integer, intent(in) :: divisions(ninterval)
+        integer, intent(out) :: node_map(0:ninterval)
+        real(kind(1.0d0)), intent(out) :: node_values(0:ninterval)
+
+        integer :: i, phi_eta_ind(0:ninterval, 2)
+
+        allocate(fieldpropagator)
+        allocate(fieldpropagator%coords)
+        allocate(fieldpropagator%coords%x2(0:ninterval))
+        fieldpropagator%coords%x2 = [(real(i, kind(1.0d0)), i = 0, ninterval)]
+
+        allocate(phi_divide(ninterval))
+        phi_divide = divisions
+        do i = 0, ninterval
+            phi_eta_ind(i, :) = i
+        end do
+
+        call phi_divider(ninterval, phi_eta_ind)
+        node_map = phi_eta_ind(:, 1)
+        node_values = phiarr(node_map)
+
+        deallocate(phiarr, phi_divide)
+        deallocate(fieldpropagator%coords%x2)
+        deallocate(fieldpropagator%coords)
+        deallocate(fieldpropagator)
+    end subroutine refined_node_map
+end program test_phi_divider_parity


### PR DESCRIPTION
Refs #127. This child is stacked on #126, #125, #119, #121, and #124 and remains open against `main`.

## Summary

- report the exact DGBSV status and solve stage when intermediate propagator joining fails
- report old/new propagator tags, matrix dimensions, and finite matrix/RHS counts
- cover the production diagnostic with a real singular DGBSV solve

## Invariants

Successful joins are unchanged. On failure, the existing stage error code and stop path remain unchanged; the change only retains diagnostics already available at the call site. It does not change the join matrix, right-hand side, pivoting, solver acceptance, discretization, convergence criteria, source weights, field-line boundary conditions, ABI, array ownership, or storage layout.

No branch in this stack is authorized to merge before the programme-wide gate.

## Verification

### Test fails before implementation

With only the behavioral test applied at parent `4b00b88`:

```text
$ cmake --build build --target test_join_failure_diagnostic
Fatal Error: Cannot open module file 'join_diagnostics_mod.mod'
ninja: build stopped: subcommand failed.
```

The parent has no production diagnostic API that can retain the LAPACK status.

### Test passes after implementation

```text
$ fo
Static: OK (333 modules)
Build: OK
Tests: OK
Lint: OK
All stages passed

$ make test
100% tests passed, 0 tests failed out of 11

$ ctest --test-dir build -R '^join_failure_diagnostic_test$' --output-on-failure
100% tests passed, 0 tests failed out of 1

$ git diff --check
<no output>
```

The singular 2x2 fixture returns `info=2`; the production diagnostic prints stage `2`, status `2`, both tag pairs, dimensions `2 2`, and finite counts `4/4` and `2/2`.

The 16 separately managed external-data regressions remain registered under `regression;external-data`; this branch does not mark that unavailable-data gate passed. Root-cause repair for #127 remains a separate child after a replayable join fixture identifies the failing pivot/input state.
