### PR TITLE
Expose NEO-2-QL integral iteration limit

### DIFF
--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -53,7 +53,7 @@ module neo2_ql
   !! End Modifications by Andreas F. Martitsch (15.07.2014)
        collop_base_prj, collop_base_exp, scalprod_alpha,            &
        scalprod_beta, lsw_read_precom, lsw_write_precom
-  USE rkstep_mod, ONLY : lag, leg, legmax, epserr_iter
+  USE rkstep_mod, ONLY : lag, leg, legmax, epserr_iter, niter
 
   USE development, ONLY : solver_talk,switch_off_asymp, &
        asymp_margin_zero, asymp_margin_npass, asymp_pardeleta,      &
@@ -210,7 +210,8 @@ module neo2_ql
        asymp_margin_zero,asymp_margin_npass,asymp_pardeleta,                  &
        ripple_solver_accurfac,                                                &
        sparse_talk,sparse_solve_method, OMP_NUM_THREADS,                      &
-       mag_symmetric,mag_symmetric_shorten, epserr_iter, lsw_linear_boozer
+       mag_symmetric,mag_symmetric_shorten, epserr_iter, niter,               &
+       lsw_linear_boozer
   NAMELIST /collision/                                                        &
        conl_over_mfp,lag,leg,legmax,z_eff,isw_lorentz,                        &
        isw_integral,isw_energy,isw_axisymm,                                   &
@@ -584,6 +585,7 @@ subroutine main
        CALL h5_add(h5_config_group, 'asymp_margin_npass', asymp_margin_npass)
        CALL h5_add(h5_config_group, 'asymp_pardeleta', asymp_pardeleta)
        CALL h5_add(h5_config_group, 'ripple_solver_accurfac', ripple_solver_accurfac)
+       CALL h5_add(h5_config_group, 'niter', niter)
        CALL h5_add(h5_config_group, 'sparse_talk', sparse_talk)
        CALL h5_add(h5_config_group, 'mag_symmetric', mag_symmetric)
        CALL h5_add(h5_config_group, 'mag_symmetric_shorten', mag_symmetric_shorten)
@@ -785,6 +787,7 @@ subroutine main
     xetami=0.0d0
     xetama=1.300001d0
     epserr_iter = 1e-5
+    niter = 1000
     eta_part_global = 0
     eta_part_trapped = 10
     eta_part_globalfac = 3.0_dp
@@ -924,6 +927,12 @@ subroutine main
     if (isw_calc_MagDrift == 0 .and. isw_mag_shear == 1) then
       write(*,*) 'ERROR: Magnetic shear without magnetic drift.'
       write(*,*) '  isw_calc_MagDrift must be 1 if isw_mag_shear == 1.'
+      write(*,*) 'Aborting...'
+      stop
+    end if
+
+    if (niter <= 0) then
+      write(*,*) 'ERROR: niter must be greater than zero.'
       write(*,*) 'Aborting...'
       stop
     end if

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -261,7 +261,6 @@ SUBROUTINE ripple_solver(                                 &
   double precision, dimension(:,:,:,:), allocatable :: dentf_p_h5, enetf_p_h5, spitf_p_h5
   double precision, dimension(:,:,:,:), allocatable :: dentf_m_h5, enetf_m_h5, spitf_m_h5
 
-  niter=1000
   isw_regper=1       !regulariization by periodic boundary condition
 
   !! Modification by Andreas F. Martitsch (28.07.2015)

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -61,3 +61,17 @@ set_tests_properties(spline_sparse_assembly_test PROPERTIES
     PASS_REGULAR_EXPRESSION "All tests passed!"
     TIMEOUT 30
 )
+
+set(QL_NITER_TEST_DIR "${CMAKE_CURRENT_BINARY_DIR}/ql_niter_validation")
+file(MAKE_DIRECTORY "${QL_NITER_TEST_DIR}")
+configure_file(fixtures/neo2_invalid_niter.in
+               "${QL_NITER_TEST_DIR}/neo2.in" COPYONLY)
+
+add_test(NAME ql_niter_validation_test
+         COMMAND $<TARGET_FILE:neo_2_ql.x>
+         WORKING_DIRECTORY "${QL_NITER_TEST_DIR}")
+
+set_tests_properties(ql_niter_validation_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "ERROR: niter must be greater than zero."
+    TIMEOUT 30
+)

--- a/TEST/fixtures/neo2_invalid_niter.in
+++ b/TEST/fixtures/neo2_invalid_niter.in
@@ -1,0 +1,15 @@
+&multi_spec
+/
+&settings
+  niter = 0
+/
+&collision
+/
+&binsplit
+/
+&propagator
+/
+&plotting
+/
+&ntv_input
+/


### PR DESCRIPTION
Closes #155.

The QL input now exposes the existing integral-part iteration limit as `niter`, keeps the current default of 1000, rejects nonpositive values before solver setup, and records the selected value in `neo2_config.h5`. The ripple solver uses that configured module value instead of overwriting it locally.

The numerical invariant is unchanged at default input: the iteration limit remains 1000, and the loop body, `epserr_iter` stopping criterion, collision operator, source terms, flux-conservation operations, ABI, and data layout are unchanged.

## Verification

- Before implementation: `fo test ql_niter_validation_test` failed (`0 passed, 1 failed`) because `niter` was not accepted by the QL settings namelist.
- After implementation: `fo test ql_niter_validation_test` passes (`1 passed, 0 failed`) and exercises the nonpositive-value rejection through the QL executable.
- `ctest --test-dir build -R 'boozmn_read_test|nrutil_test|er_rotation_test|spline_sparse_assembly_test|ql_niter_validation_test|test_mympilib' --output-on-failure` passes all 6 self-contained tests.
- Bare `fo` reports `Static: OK` and `Build: OK`, then cannot complete the legacy reconstruction tests because their site-only templates and reference files are unavailable in this environment. `fo lint` reports the existing 195 compiler warnings and 2 unused imports.
