### PR TITLE
Record active phi-grid placement decisions

### DIFF
--- a/COMMON/flint_mod.f90
+++ b/COMMON/flint_mod.f90
@@ -26,11 +26,12 @@ MODULE flint_mod
 
 contains
 
-  SUBROUTINE record_phi_placement(tag,interval,part,eta_index,phi_start, &
-       phi_end,hphi,ceiling_count,placed_count,ierr)
+  SUBROUTINE record_phi_placement(tag,outcome,interval,part,eta_index, &
+       phi_start,phi_end,hphi,decision_count,result_count,ierr)
     INTEGER, INTENT(in) :: tag,interval,part,eta_index
-    INTEGER, INTENT(in) :: ceiling_count,placed_count
+    INTEGER, INTENT(in) :: decision_count,result_count
     DOUBLE PRECISION, INTENT(in) :: phi_start,phi_end,hphi
+    CHARACTER(len=*), INTENT(in) :: outcome
     INTEGER, INTENT(out) :: ierr
 
     INTEGER :: iunit,status
@@ -47,9 +48,9 @@ contains
        RETURN
     END IF
     phi_placement_sequence = phi_placement_sequence + 1
-    WRITE(iunit,'(5(I0,","),3(ES23.15,","),I0,",",I0)',IOSTAT=status) &
-         phi_placement_sequence,tag,interval,part,eta_index,phi_start, &
-         phi_end,hphi,ceiling_count,placed_count
+    WRITE(iunit,'(2(I0,","),A,",",3(I0,","),3(ES23.15,","),I0,",",I0)', &
+         IOSTAT=status) phi_placement_sequence,tag,TRIM(outcome),interval, &
+         part,eta_index,phi_start,phi_end,hphi,decision_count,result_count
     CLOSE(iunit,IOSTAT=ierr)
     IF (status .NE. 0) ierr = status
   END SUBROUTINE record_phi_placement
@@ -76,8 +77,9 @@ contains
          ACTION='write',IOSTAT=status)
     IF (status .EQ. 0) THEN
        WRITE(iunit,'(A)',IOSTAT=status) &
-            'sequence,tag,interval,part,eta_index,phi_start,phi_end,hphi,'// &
-            'ceiling_count,placed_count'
+            'sequence,tag,outcome,interval,part,eta_index,phi_start,'// &
+            'phi_end,hphi,'// &
+            'decision_count,result_count'
        CLOSE(iunit,IOSTAT=ierr)
     END IF
     IF (status .NE. 0) ierr = status
@@ -907,8 +909,8 @@ contains
           ceiling_count = m
           m = MAX(phi_split_min,m - MOD(m+1,2))
        END IF
-       CALL record_phi_placement(fieldpropagator%tag,k,ip,i_eta,phi_sl, &
-            phi_el,hphi,ceiling_count,m,placement_ierr)
+       CALL record_phi_placement(fieldpropagator%tag,'placed',k,ip,i_eta, &
+            phi_sl,phi_el,hphi,ceiling_count,m,placement_ierr)
        IF (placement_ierr .NE. 0) &
             ERROR STOP 'phi_placer diagnostic output failed'
        dpl = (phi_el-phi_sl) / DBLE(m+1) ! local delta

--- a/COMMON/flint_mod.f90
+++ b/COMMON/flint_mod.f90
@@ -20,8 +20,70 @@ MODULE flint_mod
   LOGICAL :: bsfunc_shield
   LOGICAL :: bsfunc_lambda_loc_res
   DOUBLE PRECISION :: eta_savemem_dist1, eta_savemem_dist2, eta_savemem_sigma_mult
+  CHARACTER(len=:), ALLOCATABLE, SAVE :: phi_placement_output_filename
+  INTEGER, SAVE :: phi_placement_sequence = 0
+  LOGICAL, SAVE :: phi_placement_output_initialized = .FALSE.
 
 contains
+
+  SUBROUTINE record_phi_placement(tag,interval,part,eta_index,phi_start, &
+       phi_end,hphi,ceiling_count,placed_count,ierr)
+    INTEGER, INTENT(in) :: tag,interval,part,eta_index
+    INTEGER, INTENT(in) :: ceiling_count,placed_count
+    DOUBLE PRECISION, INTENT(in) :: phi_start,phi_end,hphi
+    INTEGER, INTENT(out) :: ierr
+
+    INTEGER :: iunit,status
+
+    ierr = 0
+    IF (.NOT. phi_placement_output_initialized) &
+         CALL initialize_phi_placement_output(ierr)
+    IF (ierr .NE. 0 .OR. &
+         .NOT. ALLOCATED(phi_placement_output_filename)) RETURN
+    OPEN(NEWUNIT=iunit,FILE=phi_placement_output_filename,STATUS='old', &
+         POSITION='append',ACTION='write',IOSTAT=status)
+    IF (status .NE. 0) THEN
+       ierr = status
+       RETURN
+    END IF
+    phi_placement_sequence = phi_placement_sequence + 1
+    WRITE(iunit,'(5(I0,","),3(ES23.15,","),I0,",",I0)',IOSTAT=status) &
+         phi_placement_sequence,tag,interval,part,eta_index,phi_start, &
+         phi_end,hphi,ceiling_count,placed_count
+    CLOSE(iunit,IOSTAT=ierr)
+    IF (status .NE. 0) ierr = status
+  END SUBROUTINE record_phi_placement
+
+  SUBROUTINE initialize_phi_placement_output(ierr)
+    INTEGER, INTENT(out) :: ierr
+
+    INTEGER :: iunit,length,status
+
+    ierr = 0
+    phi_placement_output_initialized = .TRUE.
+    CALL GET_ENVIRONMENT_VARIABLE('NEO2_PHI_PLACEMENT_FILE',LENGTH=length, &
+         STATUS=status)
+    IF (status .NE. 0 .OR. length .EQ. 0) RETURN
+    ALLOCATE(CHARACTER(len=length) :: phi_placement_output_filename)
+    CALL GET_ENVIRONMENT_VARIABLE('NEO2_PHI_PLACEMENT_FILE', &
+         VALUE=phi_placement_output_filename,STATUS=status)
+    IF (status .NE. 0) THEN
+       ierr = status
+       DEALLOCATE(phi_placement_output_filename)
+       RETURN
+    END IF
+    OPEN(NEWUNIT=iunit,FILE=phi_placement_output_filename,STATUS='replace', &
+         ACTION='write',IOSTAT=status)
+    IF (status .EQ. 0) THEN
+       WRITE(iunit,'(A)',IOSTAT=status) &
+            'sequence,tag,interval,part,eta_index,phi_start,phi_end,hphi,'// &
+            'ceiling_count,placed_count'
+       CLOSE(iunit,IOSTAT=ierr)
+    END IF
+    IF (status .NE. 0) ierr = status
+    IF (ierr .NE. 0 .AND. ALLOCATED(phi_placement_output_filename)) &
+         DEALLOCATE(phi_placement_output_filename)
+  END SUBROUTINE initialize_phi_placement_output
 
   !> this routine is called before flint and does the setup for magnetics
   !> it creates the
@@ -627,6 +689,7 @@ contains
 
     ! local stuff
     INTEGER :: imin,ub,ip,ips,ipe,iphi,i_eta,k,ie_dir,i,m,n
+    INTEGER :: ceiling_count,placement_ierr
     INTEGER :: phi_count,arr_phi_count
     INTEGER :: nfp,nstep
 
@@ -838,10 +901,16 @@ contains
        ! last one is only recorded for the last sub-intervall
        IF (phi_place_mode .EQ. 1) THEN
           m = 1 ! or only one point
+          ceiling_count = 1
        ELSE
           m = CEILING((phi_el-phi_sl)/(hphi))
+          ceiling_count = m
           m = MAX(phi_split_min,m - MOD(m+1,2))
        END IF
+       CALL record_phi_placement(fieldpropagator%tag,k,ip,i_eta,phi_sl, &
+            phi_el,hphi,ceiling_count,m,placement_ierr)
+       IF (placement_ierr .NE. 0) &
+            ERROR STOP 'phi_placer diagnostic output failed'
        dpl = (phi_el-phi_sl) / DBLE(m+1) ! local delta
 
        IF (k .EQ. arr_phi_count) m = m+1 ! for the last one

--- a/NEO-2-QL/flint.f90
+++ b/NEO-2-QL/flint.f90
@@ -2079,7 +2079,8 @@ SUBROUTINE modify_propagator(phi_split_mode,phi_place_mode,phi_split_min, &
   ! input/output
   USE partpa_mod, ONLY : ipmax,ipmin
 
-  USE flint_mod, ONLY : phiarr,plot_prop, phi_divider, phi_placer
+  USE flint_mod, ONLY : phiarr,plot_prop, phi_divider, phi_placer, &
+       record_phi_placement
   USE magnetics_mod
   USE device_mod
   USE binarysplit_mod
@@ -2119,10 +2120,12 @@ SUBROUTINE modify_propagator(phi_split_mode,phi_place_mode,phi_split_min, &
   INTEGER,       ALLOCATABLE :: phi_eta_ind(:,:)
   REAL(kind=dp), ALLOCATABLE :: o_eta_split(:)
   REAL(kind=dp) :: phibeg,phiend,hphi,phi
+  REAL(kind=dp) :: diagnostic_hphi
   REAL(kind=dp) :: bhat1,b1
   TYPE(fieldpropagator_struct), POINTER :: plotpropagator
 
-  INTEGER :: phi_placer_status
+  INTEGER :: phi_placer_status,placement_ierr
+  CHARACTER(len=16) :: placement_outcome
 
   INTEGER :: ubn
   INTEGER :: nlagrange = 5
@@ -2141,11 +2144,13 @@ SUBROUTINE modify_propagator(phi_split_mode,phi_place_mode,phi_split_min, &
   ALLOCATE(phi_eta_ind(0:u_eta,2))
   phi_eta_ind(:,1) = 0
   phi_eta_ind(:,2) = -1
+  placement_outcome = ''
 
   ! constuct new phi-values
   IF (phi_split_mode .EQ. 1) THEN
      ! split steps into half
      CALL linspace(phibeg,phiend,2*ub+1,phiarr)
+     placement_outcome = 'halfstep'
   ELSE IF (phi_split_mode .EQ. 2) THEN
      ! split according to eta_split
      ALLOCATE (o_eta_split(1:UBOUND(eta_split,1)))
@@ -2157,13 +2162,25 @@ SUBROUTINE modify_propagator(phi_split_mode,phi_place_mode,phi_split_min, &
         ! there is no eta-value available for this phi_range (intervall too small)
         ! split steps into half as in phi_split_mode .eq. 1
         CALL linspace(phibeg,phiend,2*ub+1,phiarr)
+        placement_outcome = 'no_eta_halfstep'
      END IF
   ELSE IF (phi_split_mode .EQ. 3) THEN
      ! new mode according to phi_divide
      CALL phi_divider(u_eta,phi_eta_ind)
+     placement_outcome = 'divider'
   ELSE
      PRINT *, 'not implemented'
      STOP
+  END IF
+
+  IF (LEN_TRIM(placement_outcome) .GT. 0) THEN
+     diagnostic_hphi = 0.0_dp
+     IF (ub .GT. 0) diagnostic_hphi = (phiend-phibeg)/DBLE(ub)
+     CALL record_phi_placement(fieldpropagator%tag,placement_outcome, &
+          0,0,-1,phibeg,phiend,diagnostic_hphi,ub+1, &
+          UBOUND(phiarr,1)+1,placement_ierr)
+     IF (placement_ierr .NE. 0) &
+          ERROR STOP 'modify_propagator diagnostic output failed'
   END IF
 
   ! now make the new RK-steps for pre-computed phi-values

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -125,6 +125,20 @@ set_tests_properties(phi_divider_parity_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_phi_placement_diagnostic test_phi_placement_diagnostic.f90)
+target_link_libraries(test_phi_placement_diagnostic common)
+
+add_test(NAME phi_placement_diagnostic_test
+         COMMAND test_phi_placement_diagnostic
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(phi_placement_diagnostic_test PROPERTIES
+    ENVIRONMENT "NEO2_PHI_PLACEMENT_FILE=${CMAKE_CURRENT_BINARY_DIR}/phi_placement.csv"
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_join_failure_diagnostic test_join_failure_diagnostic.f90)
 target_link_libraries(test_join_failure_diagnostic neo2_ql)
 

--- a/TEST/test_phi_placement_diagnostic.f90
+++ b/TEST/test_phi_placement_diagnostic.f90
@@ -1,0 +1,36 @@
+program test_phi_placement_diagnostic
+    use, intrinsic :: iso_fortran_env, only: real64
+    use flint_mod, only: record_phi_placement
+
+    implicit none
+
+    character(len=512) :: filename, header
+    integer :: ceiling_count, eta_index, interval, ierr, iunit, part
+    integer :: placed_count, sequence, status, tag
+    real(real64) :: hphi, phi_end, phi_start
+
+    call record_phi_placement(12, 3, 2, 7, 1.0_real64, 1.5_real64, &
+        0.1_real64, 5, 5, ierr)
+    if (ierr /= 0) error stop 'FAIL: phi placement record returned an error'
+    call get_environment_variable('NEO2_PHI_PLACEMENT_FILE', filename)
+    open(newunit=iunit, file=trim(filename), status='old', action='read', &
+        iostat=status)
+    if (status /= 0) error stop 'FAIL: phi placement output is absent'
+    read(iunit, '(a)', iostat=status) header
+    if (status /= 0 .or. trim(header) /= &
+        'sequence,tag,interval,part,eta_index,phi_start,phi_end,hphi,'// &
+        'ceiling_count,placed_count') &
+        error stop 'FAIL: phi placement header is wrong'
+    read(iunit, *, iostat=status) sequence, tag, interval, part, eta_index, &
+        phi_start, phi_end, hphi, ceiling_count, placed_count
+    close(iunit)
+    if (status /= 0 .or. sequence /= 1 .or. tag /= 12 .or. interval /= 3 &
+        .or. part /= 2 .or. eta_index /= 7 .or. ceiling_count /= 5 &
+        .or. placed_count /= 5 .or. abs(phi_start - 1.0_real64) &
+        > 1.0e-15_real64 .or. abs(phi_end - 1.5_real64) &
+        > 1.0e-15_real64 .or. abs(hphi - 0.1_real64) &
+        > 1.0e-15_real64) &
+        error stop 'FAIL: phi placement record is wrong'
+
+    print '(a)', 'All tests passed!'
+end program test_phi_placement_diagnostic

--- a/TEST/test_phi_placement_diagnostic.f90
+++ b/TEST/test_phi_placement_diagnostic.f90
@@ -5,11 +5,12 @@ program test_phi_placement_diagnostic
     implicit none
 
     character(len=512) :: filename, header
-    integer :: ceiling_count, eta_index, interval, ierr, iunit, part
-    integer :: placed_count, sequence, status, tag
+    character(len=16) :: outcome
+    integer :: decision_count, eta_index, interval, ierr, iunit, part
+    integer :: result_count, sequence, status, tag
     real(real64) :: hphi, phi_end, phi_start
 
-    call record_phi_placement(12, 3, 2, 7, 1.0_real64, 1.5_real64, &
+    call record_phi_placement(12, 'placed', 3, 2, 7, 1.0_real64, 1.5_real64, &
         0.1_real64, 5, 5, ierr)
     if (ierr /= 0) error stop 'FAIL: phi placement record returned an error'
     call get_environment_variable('NEO2_PHI_PLACEMENT_FILE', filename)
@@ -18,15 +19,16 @@ program test_phi_placement_diagnostic
     if (status /= 0) error stop 'FAIL: phi placement output is absent'
     read(iunit, '(a)', iostat=status) header
     if (status /= 0 .or. trim(header) /= &
-        'sequence,tag,interval,part,eta_index,phi_start,phi_end,hphi,'// &
-        'ceiling_count,placed_count') &
+        'sequence,tag,outcome,interval,part,eta_index,phi_start,phi_end,hphi,'// &
+        'decision_count,result_count') &
         error stop 'FAIL: phi placement header is wrong'
-    read(iunit, *, iostat=status) sequence, tag, interval, part, eta_index, &
-        phi_start, phi_end, hphi, ceiling_count, placed_count
+    read(iunit, *, iostat=status) sequence, tag, outcome, interval, part, &
+        eta_index, phi_start, phi_end, hphi, decision_count, result_count
     close(iunit)
-    if (status /= 0 .or. sequence /= 1 .or. tag /= 12 .or. interval /= 3 &
-        .or. part /= 2 .or. eta_index /= 7 .or. ceiling_count /= 5 &
-        .or. placed_count /= 5 .or. abs(phi_start - 1.0_real64) &
+    if (status /= 0 .or. sequence /= 1 .or. tag /= 12 &
+        .or. trim(outcome) /= 'placed' .or. interval /= 3 &
+        .or. part /= 2 .or. eta_index /= 7 .or. decision_count /= 5 &
+        .or. result_count /= 5 .or. abs(phi_start - 1.0_real64) &
         > 1.0e-15_real64 .or. abs(phi_end - 1.5_real64) &
         > 1.0e-15_real64 .or. abs(hphi - 0.1_real64) &
         > 1.0e-15_real64) &


### PR DESCRIPTION
## Summary

This PR adds an opt-in record of the phi-grid strategy that `modify_propagator` actually applies.

The first implementation recorded only automatic `phi_placer` intervals. A production reconstruction then emitted no CSV because its configured path uses `phi_split_mode=1`; the automatic eta placer is never called. The recorder now covers the decision boundary shared by all modes:

- `placed`: automatic eta-interval placement, with the raw `CEILING` decision and the count after the existing odd/minimum adjustment;
- `halfstep`: configured mode-1 refinement, with input and output grid-point counts;
- `no_eta_halfstep`: the mode-2 fallback when no eta value lies in the propagator interval;
- `divider`: the mode-3 retry path, with input and output grid-point counts.

Each row identifies the propagator and outcome. It also records the interval, branch, eta index, phi endpoints, and original phi spacing. The generic count columns are named `decision_count` and `result_count` because their exact meaning is strategy-specific.

## Behavior and invariants

Set `NEO2_PHI_PLACEMENT_FILE` to request the CSV. With the variable unset, the recorder performs no allocation or file I/O. A requested path that cannot be written is a hard error rather than an incomplete record.

The diagnostic does not change the selected strategy, `CEILING` expression, parity adjustment, half-step or divider grid, point locations, field-line integration, source, collision operator, join normalization, convergence criteria, ABI, or generated physics-data layout. It only observes the grid before `modify_propagator` replaces the old coordinates.

## Relation to the flux-pumping stack

This branch is stacked on PR #154 because the downstream convergence campaign uses one pinned executable history. It does not depend on the join-normalization values. The record is intended to distinguish a response change caused by a phi-grid strategy or count transition from a downstream change.

## Verification

Failing before the recorder existed:

```text
phi_placement_diagnostic_test: record_phi_placement is absent
```

The first production attempt at the previous head also failed strict validation because no requested CSV was created. That exposed the process-coverage gap: the unit test exercised the writer, but the carrier never entered automatic placement.

Focused test at `defe172`:

```text
phi_placement_diagnostic_test  PASS  0.06s
Summary: 1 passed, 0 failed, 0 skipped
```

Full repository pipeline:

```text
Static: OK (348 modules, 348 changed, 348 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed
Fmt: WARN
```

The format warning is existing whole-file drift in `COMMON/flint_mod.f90` and `NEO-2-QL/flint.f90`; the touched lines and staged diff pass whitespace and line-length checks.

A real three-stage reconstruction at `nstep=480` now writes 203 validated rows in stage 0 and 203 in stage 2. The records are byte-identical between those stages: 199 use `halfstep` and four use the `divider` retry path. Decision counts span 5-865 grid points and result counts span 9-1739. The solve retains 199 reconstructed responses and closes qflux below `8.7e-15` relative error.
