### PR TITLE
Preserve solved source distributions in propagators

### DIFF
--- a/NEO-2-QL/qflux_profile_mod.f90
+++ b/NEO-2-QL/qflux_profile_mod.f90
@@ -1,10 +1,16 @@
 module qflux_profile_mod
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
     use nrtype, only: dp
     implicit none
     private
 
+    character(len=:), allocatable, save :: interface_trace_filename
+    integer, save :: interface_trace_sequence = 0
+    logical, save :: interface_trace_initialized = .false.
+
     public :: qflux_contributions_from_flux_vector
     public :: qflux_point_components_from_flux_vector
+    public :: record_qflux_interface_traces
 
 contains
 
@@ -102,4 +108,139 @@ contains
             channel = channel + contribution(i)
         end do
     end subroutine qflux_point_components_from_flux_vector
+
+    subroutine record_qflux_interface_traces(tag, phi, eta_grid, block_base, &
+            block_npassing, lag, step_plus, step_minus, flux_row, source_rhs, &
+            source_solution, ierr)
+        integer, intent(in) :: tag, block_base(:), block_npassing(:), lag
+        real(dp), intent(in) :: phi(:), eta_grid(0:), step_plus(:), step_minus(:)
+        real(dp), intent(in) :: flux_row(:), source_rhs(:, :)
+        real(dp), intent(in) :: source_solution(:, :)
+        integer, intent(out) :: ierr
+        character(len=5) :: side
+        integer :: band, base, column, endpoint, force, iunit, m, nband, point
+        integer :: status
+
+        ierr = 0
+        if (.not. interface_trace_initialized) call initialize_interface_trace(ierr)
+        if (ierr /= 0 .or. .not. allocated(interface_trace_filename)) return
+        if (size(phi) /= size(block_base) &
+            .or. size(block_npassing) /= size(block_base) &
+            .or. size(step_plus) /= size(block_base) &
+            .or. size(step_minus) /= size(block_base) &
+            .or. size(source_rhs, 1) /= size(flux_row) &
+            .or. any(shape(source_solution) /= shape(source_rhs)) &
+            .or. size(source_rhs, 2) /= 3 &
+            .or. lag < 0) then
+            ierr = 1
+            return
+        end if
+        if (size(block_base) < 2 &
+            .or. maxval(block_npassing) >= size(eta_grid) &
+            .or. any(block_npassing < 0) &
+            .or. any(step_plus == 0.0_dp) &
+            .or. any(step_minus == 0.0_dp)) then
+            ierr = 1
+            return
+        end if
+        if (.not. all(ieee_is_finite(phi)) &
+            .or. .not. all(ieee_is_finite(eta_grid)) &
+            .or. .not. all(ieee_is_finite(step_plus)) &
+            .or. .not. all(ieee_is_finite(step_minus)) &
+            .or. .not. all(ieee_is_finite(flux_row)) &
+            .or. .not. all(ieee_is_finite(source_rhs)) &
+            .or. .not. all(ieee_is_finite(source_solution))) then
+            ierr = 1
+            return
+        end if
+
+        open(newunit=iunit, file=interface_trace_filename, status='old', &
+            position='append', action='write', iostat=status)
+        if (status /= 0) then
+            ierr = status
+            return
+        end if
+        do endpoint = 1, 2
+            if (endpoint == 1) then
+                point = 1
+                side = 'left'
+            else
+                point = size(block_base)
+                side = 'right'
+            end if
+            nband = block_npassing(point) + 1
+            do m = 0, lag
+                base = block_base(point) + 2*m*nband
+                do band = 1, nband
+                    column = base + band
+                    do force = 1, 3
+                        call write_interface_trace(iunit, tag, side, 'p', m, &
+                            force, band - 1, eta_grid(band - 1), phi(point), &
+                            flux_row(column)/step_plus(point), &
+                            source_rhs(column, force), &
+                            source_solution(column, force), status)
+                        if (status /= 0) exit
+                    end do
+                    if (status /= 0) exit
+                    column = base + 2*nband - band + 1
+                    do force = 1, 3
+                        call write_interface_trace(iunit, tag, side, 'm', m, &
+                            force, band - 1, eta_grid(band - 1), phi(point), &
+                            flux_row(column)/step_minus(point), &
+                            source_rhs(column, force), &
+                            source_solution(column, force), status)
+                        if (status /= 0) exit
+                    end do
+                    if (status /= 0) exit
+                end do
+                if (status /= 0) exit
+            end do
+            if (status /= 0) exit
+        end do
+        close(iunit, iostat=ierr)
+        if (status /= 0) ierr = status
+    end subroutine record_qflux_interface_traces
+
+    subroutine write_interface_trace(iunit, tag, side, direction, laguerre, &
+            force, eta_index, eta_value, phi, flux_kernel, source_rhs, &
+            source_solution, status)
+        integer, intent(in) :: iunit, tag, laguerre, force, eta_index
+        character(len=*), intent(in) :: side, direction
+        real(dp), intent(in) :: eta_value, phi, flux_kernel, source_rhs
+        real(dp), intent(in) :: source_solution
+        integer, intent(out) :: status
+
+        interface_trace_sequence = interface_trace_sequence + 1
+        write(iunit, '(2(i0,","),a,",",a,",",3(i0,","),4(es25.16e3,","),' // &
+            'es25.16e3)', iostat=status) interface_trace_sequence, tag, &
+            trim(side), direction, laguerre, force, eta_index, eta_value, phi, &
+            flux_kernel, source_rhs, source_solution
+    end subroutine write_interface_trace
+
+    subroutine initialize_interface_trace(ierr)
+        integer, intent(out) :: ierr
+        integer :: iunit, length, status
+
+        ierr = 0
+        interface_trace_initialized = .true.
+        call get_environment_variable('NEO2_INTERFACE_TRACE_FILE', &
+            length=length, status=status)
+        if (status /= 0 .or. length == 0) return
+        allocate(character(len=length) :: interface_trace_filename)
+        call get_environment_variable('NEO2_INTERFACE_TRACE_FILE', &
+            value=interface_trace_filename, status=status)
+        if (status == 0) then
+            open(newunit=iunit, file=interface_trace_filename, status='replace', &
+                action='write', iostat=status)
+        end if
+        if (status == 0) then
+            write(iunit, '(a)', iostat=status) &
+                'sequence,tag,side,direction,laguerre,force,eta_index,eta,phi,' // &
+                'flux_kernel,source_rhs,source_solution'
+            close(iunit, iostat=ierr)
+        end if
+        if (status /= 0) ierr = status
+        if (ierr /= 0 .and. allocated(interface_trace_filename)) &
+            deallocate(interface_trace_filename)
+    end subroutine initialize_interface_trace
 end module qflux_profile_mod

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -96,7 +96,7 @@ SUBROUTINE ripple_solver(                                 &
        clight_hel => c,echarge_hel => e
   USE partpa_mod, ONLY : bmod0
   USE qflux_profile_mod, ONLY : qflux_contributions_from_flux_vector, &
-       qflux_point_components_from_flux_vector
+       qflux_point_components_from_flux_vector, record_qflux_interface_traces
   !! End Modification by Andreas F. Martitsch (28.07.2015)
 
   IMPLICIT NONE
@@ -249,7 +249,7 @@ SUBROUTINE ripple_solver(                                 &
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: cp_raw_p,cp_raw_m
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: cp_step_p,cp_step_m
   DOUBLE PRECISION, DIMENSION(3)                :: cp_channel
-  INTEGER :: cp_istep,cp_k,cp_unit
+  INTEGER :: cp_istep,cp_k,cp_trace_status,cp_unit
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: dlogbdphi_mfl
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: delt_pos,delt_neg
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: fact_pos_b,fact_neg_b
@@ -2827,6 +2827,14 @@ ENDDO
 ! weight; the field-line sum reproduces qflux(2,k) exactly. Guarded so runs
 ! without the helical drive are bitwise unchanged.
 IF (isw_hel_drive.NE.0 .AND. num_spec.EQ.1 .AND. mpro%getrank().EQ.0) THEN
+   IF (iplot.EQ.1) THEN
+      CALL record_qflux_interface_traces(fieldpropagator%tag, &
+           phi_mfl(ibeg:iend),eta,ind_start(ibeg:iend),npl(ibeg:iend),lag, &
+           cp_step_p,cp_step_m,flux_vector(2,:),source_vector, &
+           source_vector_all(:,:,0),cp_trace_status)
+      IF (cp_trace_status.NE.0) &
+         ERROR STOP 'qflux interface trace diagnostic failed'
+   END IF
    ALLOCATE(cp_c(ibeg:iend,3))
    IF (iplot.EQ.1) ALLOCATE(cp_raw_p(ibeg:iend,3),cp_raw_m(ibeg:iend,3))
    DO cp_k=1,3
@@ -2928,10 +2936,10 @@ call cpu_time(time2)
     do kk=1,3
       k=ind_start(ibeg)+2*npass_l*m
       source_m(npass_l*m+1:npass_l*m+npass_l,kk) &
-          =source_vector(k+2*npass_l:k+npass_l+1:-1,kk)
+          =source_vector_all(k+2*npass_l:k+npass_l+1:-1,kk,ispec)
       k=ind_start(iend)+2*npass_r*m
       source_p(npass_r*m+1:npass_r*m+npass_r,kk) &
-          =source_vector(k+1:k+npass_r,kk)
+          =source_vector_all(k+1:k+npass_r,kk,ispec)
     enddo
   enddo
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -153,6 +153,20 @@ set_tests_properties(join_failure_diagnostic_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_qflux_interface_diagnostic test_qflux_interface_diagnostic.f90)
+target_link_libraries(test_qflux_interface_diagnostic neo2_ql)
+
+add_test(NAME qflux_interface_diagnostic_test
+         COMMAND test_qflux_interface_diagnostic
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(qflux_interface_diagnostic_test PROPERTIES
+    ENVIRONMENT "NEO2_INTERFACE_TRACE_FILE=${CMAKE_CURRENT_BINARY_DIR}/qflux_interface_trace.csv"
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_ripple_solver_route test_ripple_solver_route.f90)
 target_link_libraries(test_ripple_solver_route neo2_ql)
 

--- a/TEST/test_qflux_interface_diagnostic.f90
+++ b/TEST/test_qflux_interface_diagnostic.f90
@@ -1,0 +1,67 @@
+program test_qflux_interface_diagnostic
+    use, intrinsic :: iso_fortran_env, only: real64
+    use qflux_profile_mod, only: record_qflux_interface_traces
+    implicit none
+
+    character(len=512) :: filename, header
+    character(len=5) :: side
+    character(len=1) :: direction
+    integer :: band, force, i, ierr, iunit, laguerre, sequence, status, tag
+    integer :: block_base(2), block_npassing(2), rows
+    real(real64) :: eta, eta_grid(0:1), flux_kernel, flux_row(8), phi
+    real(real64) :: phi_grid(2), solution(8, 3), source_rhs, rhs(8, 3)
+    real(real64) :: step_minus(2), step_plus(2), value
+    logical :: found_counter_record
+
+    block_base = [0, 4]
+    block_npassing = 1
+    eta_grid = [0.25_real64, 0.75_real64]
+    phi_grid = [1.0_real64, 2.0_real64]
+    step_plus = [2.0_real64, 4.0_real64]
+    step_minus = [5.0_real64, 10.0_real64]
+    flux_row = [(real(i, real64), i = 1, size(flux_row))]
+    rhs = reshape([(100.0_real64 + real(i, real64), i = 1, size(rhs))], &
+        shape(rhs))
+    solution = rhs + 1000.0_real64
+
+    call record_qflux_interface_traces(12, phi_grid, eta_grid, block_base, &
+        block_npassing, 0, step_plus, step_minus, flux_row, rhs, solution, ierr)
+    if (ierr /= 0) error stop 'FAIL: interface trace record returned an error'
+    call get_environment_variable('NEO2_INTERFACE_TRACE_FILE', filename)
+    open(newunit=iunit, file=trim(filename), status='old', action='read', &
+        iostat=status)
+    if (status /= 0) error stop 'FAIL: interface trace output is absent'
+    read(iunit, '(a)', iostat=status) header
+    if (status /= 0 .or. trim(header) /= &
+        'sequence,tag,side,direction,laguerre,force,eta_index,eta,phi,' // &
+        'flux_kernel,source_rhs,source_solution') &
+        error stop 'FAIL: interface trace header is wrong'
+
+    rows = 0
+    found_counter_record = .false.
+    do
+        read(iunit, *, iostat=status) sequence, tag, side, direction, laguerre, &
+            force, band, eta, phi, flux_kernel, source_rhs, value
+        if (status < 0) exit
+        if (status > 0) error stop 'FAIL: interface trace row cannot be read'
+        rows = rows + 1
+        if (sequence /= rows .or. tag /= 12 .or. laguerre /= 0) &
+            error stop 'FAIL: interface trace identity is wrong'
+        if (trim(side) == 'right' .and. direction == 'm' .and. band == 1 &
+            .and. force == 3) then
+            found_counter_record = .true.
+            if (abs(eta - 0.75_real64) > 1.0e-15_real64 &
+                .or. abs(phi - 2.0_real64) > 1.0e-15_real64 &
+                .or. abs(flux_kernel - 0.7_real64) > 1.0e-15_real64 &
+                .or. abs(source_rhs - rhs(7, 3)) > 1.0e-15_real64 &
+                .or. abs(value - solution(7, 3)) > 1.0e-15_real64) &
+                error stop 'FAIL: counter-passing trace mapping is wrong'
+        end if
+    end do
+    close(iunit)
+    if (rows /= 24) error stop 'FAIL: interface trace row count is wrong'
+    if (.not. found_counter_record) &
+        error stop 'FAIL: expected counter-passing trace record is absent'
+
+    print '(a)', 'All tests passed!'
+end program test_qflux_interface_diagnostic


### PR DESCRIPTION
The local solver stored source_p and source_m from the assembled right-hand side after the 2015 multispecies path moved the solved distribution to source_vector_all. Propagator reconstruction therefore combined solved boundary-response matrices with unsolved internal-source endpoints. Stage 1 was self-consistent with that saved map, but stage 2 solved a different map and produced percent-level internal jumps.

Read both outgoing source blocks from source_vector_all for the active species. This restores the documented propagator relation between incoming and outgoing distributions. It does not change the collision operator, source assembly, spatial or pitch discretization, convergence criteria, Fourier convention, CGS units, boundary conditions, ABI, or array layout.

An opt-in NEO2_INTERFACE_TRACE_FILE diagnostic records left and right kernel, assembled RHS, and solved-distribution rows under stable propagator, direction, force, Laguerre, and pitch identities. It allocates and writes nothing when disabled. Invalid shapes, nonfinite values, and I/O failures stop the diagnostic run.

At 480 spatial steps and eta_part=30, the corrected replay reproduces all 199 saved local propagator maps to 5.34e-15 relative. All 198 internal joins are continuous to 5.96e-15. The former 2.49% and 5.74% internal current jumps are gone. A separate 7.28e-4 periodic distribution residual remains because join_ends replaces one periodic equation with the Lorentz closure constraint; this PR does not change that nullspace treatment.

## Verification
### Test fails on integration head

Command:
    FLUX_PUMPING_INTERFACE_TRACE=1 FLUX_PUMPING_NSTEP=480 FLUX_PUMPING_ETA_PART=30 python3 run_reconstruction.py <integration-checkout>

Observed at 73d6764:
    incoming_replay_max_absolute_error: p=0, m=0
    stage1_internal_map_max_relative_error: p=4.02e-15, m=7.27e-16
    stage2_propagator_map_max_relative_error: p=3.85e-2, m=3.87e-2
    one-sided current jumps: A1=2.49e-2, A2=5.74e-2

### Test passes after fix

Commands and output:
    fo test qflux_interface_diagnostic_test
    qflux_interface_diagnostic_test PASS

    fo
    Static: OK
    Build: OK
    Tests: OK
    Lint: OK
    Fmt: WARN (pre-existing whole-file formatting in ripple_solver_axi_test.f90)

Production replay at 130ea2c:
    incoming_replay_max_absolute_error: p=0, m=0
    stage1_internal_map_max_relative_error: p=4.23e-15, m=9.22e-16
    stage2_propagator_map_max_relative_error: p=5.34e-15, m=3.85e-15
    max internal solved-distribution mismatch: 5.96e-15
    max internal current-contraction mismatch: 2.97e-15
    qflux relative closure: A1=3.59e-15, A2=4.12e-16
    artifacts: 199 reconstructed boundaries, 199 local-response files, 59,736 trace rows