### PR TITLE
Trace periodic join compatibility and nullspace

### DIFF
--- a/NEO-2-QL/join_diagnostics_mod.f90
+++ b/NEO-2-QL/join_diagnostics_mod.f90
@@ -182,13 +182,16 @@ contains
             .or. .not. all(ieee_is_finite(right_residual)) &
             .or. .not. all(ieee_is_finite(left_scale)) &
             .or. .not. all(ieee_is_finite(right_scale)) &
-            .or. any(compatibility_scale <= 0.0_real64) &
+            .or. .not. all(ieee_is_finite(transfer_error))) then
+            ierr = 7
+            return
+        end if
+        if (any(compatibility_scale <= 0.0_real64) &
             .or. any(dropped_p_scale <= 0.0_real64) &
             .or. any(dropped_m_scale <= 0.0_real64) &
             .or. any(left_scale <= 0.0_real64) &
             .or. any(right_scale <= 0.0_real64) &
-            .or. any(source_scale <= 0.0_real64) &
-            .or. .not. all(ieee_is_finite(transfer_error))) then
+            .or. any(source_scale <= 0.0_real64)) then
             ierr = 7
             return
         end if

--- a/NEO-2-QL/join_diagnostics_mod.f90
+++ b/NEO-2-QL/join_diagnostics_mod.f90
@@ -1,12 +1,18 @@
 module join_diagnostics_mod
     use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use, intrinsic :: iso_fortran_env, only: real64
     implicit none
     private
 
     character(len=:), allocatable, save :: normalization_output_filename
+    character(len=:), allocatable, save :: join_end_output_filename
     integer, save :: normalization_sequence = 0
+    integer, save :: join_end_record = 0
+    integer, save :: join_end_sequence = 0
     logical, save :: normalization_output_initialized = .false.
+    logical, save :: join_end_output_initialized = .false.
 
+    public :: join_end_trace_enabled, record_join_end_compatibility
     public :: report_join_failure, validate_join_normalization
 
 contains
@@ -14,7 +20,7 @@ contains
     subroutine report_join_failure(stage, info, old_tags, new_tags, ndim, ndim1, &
             matrix, rhs, ierr)
         integer, intent(in) :: stage, info, old_tags(2), new_tags(2), ndim, ndim1
-        real(kind(1.0d0)), intent(in) :: matrix(:, :), rhs(:, :)
+        real(real64), intent(in) :: matrix(:, :), rhs(:, :)
         integer, intent(out) :: ierr
 
         write(*, '(a,i0)') 'join_ripples: DGBSV stage=', stage
@@ -31,7 +37,7 @@ contains
 
     subroutine validate_join_normalization(facnorm, direction, column, old_tags, &
             new_tags, npass_l, npass_r, ierr)
-        real(kind(1.0d0)), intent(in) :: facnorm
+        real(real64), intent(in) :: facnorm
         character(len=1), intent(in) :: direction
         integer, intent(in) :: column, old_tags(2), new_tags(2), npass_l, npass_r
         integer, intent(out) :: ierr
@@ -53,7 +59,7 @@ contains
 
     subroutine record_join_normalization(facnorm, direction, column, old_tags, &
             new_tags, npass_l, npass_r, ierr)
-        real(kind(1.0d0)), intent(in) :: facnorm
+        real(real64), intent(in) :: facnorm
         character(len=1), intent(in) :: direction
         integer, intent(in) :: column, old_tags(2), new_tags(2), npass_l, npass_r
         integer, intent(out) :: ierr
@@ -113,4 +119,183 @@ contains
             ierr = 6
         end if
     end subroutine initialize_normalization_output
+
+    logical function join_end_trace_enabled(ierr)
+        integer, intent(out) :: ierr
+
+        ierr = 0
+        if (.not. join_end_output_initialized) call initialize_join_end_output(ierr)
+        join_end_trace_enabled = allocated(join_end_output_filename)
+    end function join_end_trace_enabled
+
+    subroutine record_join_end_compatibility(source_factor, source_before, &
+            source_after, source_scale, measure_sum, compatibility, &
+            dropped_p, dropped_m, &
+            compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
+            right_null, left_residual, right_residual, left_scale, right_scale, &
+            transfer_error, ierr)
+        real(real64), intent(in) :: source_factor(3), source_before(3)
+        real(real64), intent(in) :: source_after(3), source_scale(3), measure_sum
+        real(real64), intent(in) :: compatibility(:, :), dropped_p(:, :)
+        real(real64), intent(in) :: dropped_m(:, :), left_null(:, :)
+        real(real64), intent(in) :: compatibility_scale(:, :)
+        real(real64), intent(in) :: dropped_p_scale(:, :), dropped_m_scale(:, :)
+        real(real64), intent(in) :: right_null(:, :), left_residual(:)
+        real(real64), intent(in) :: right_residual(:), left_scale(:)
+        real(real64), intent(in) :: right_scale(:), transfer_error(2)
+        integer, intent(out) :: ierr
+
+        integer :: force, index, iunit, laguerre, status
+
+        ierr = 0
+        if (.not. join_end_trace_enabled(ierr)) return
+        if (ierr /= 0) return
+        if (size(compatibility, 2) /= 3 &
+            .or. any(shape(dropped_p) /= shape(compatibility)) &
+            .or. any(shape(dropped_m) /= shape(compatibility)) &
+            .or. any(shape(compatibility_scale) /= shape(compatibility)) &
+            .or. any(shape(dropped_p_scale) /= shape(compatibility)) &
+            .or. any(shape(dropped_m_scale) /= shape(compatibility)) &
+            .or. size(left_null, 2) /= size(compatibility, 1) &
+            .or. any(shape(right_null) /= shape(left_null)) &
+            .or. size(left_residual) /= size(compatibility, 1) &
+            .or. size(right_residual) /= size(compatibility, 1) &
+            .or. size(left_scale) /= size(compatibility, 1) &
+            .or. size(right_scale) /= size(compatibility, 1)) then
+            ierr = 7
+            return
+        end if
+        if (.not. all(ieee_is_finite(source_factor)) &
+            .or. .not. all(ieee_is_finite(source_before)) &
+            .or. .not. all(ieee_is_finite(source_after)) &
+            .or. .not. all(ieee_is_finite(source_scale)) &
+            .or. .not. ieee_is_finite(measure_sum) &
+            .or. .not. all(ieee_is_finite(compatibility)) &
+            .or. .not. all(ieee_is_finite(dropped_p)) &
+            .or. .not. all(ieee_is_finite(dropped_m)) &
+            .or. .not. all(ieee_is_finite(compatibility_scale)) &
+            .or. .not. all(ieee_is_finite(dropped_p_scale)) &
+            .or. .not. all(ieee_is_finite(dropped_m_scale)) &
+            .or. .not. all(ieee_is_finite(left_null)) &
+            .or. .not. all(ieee_is_finite(right_null)) &
+            .or. .not. all(ieee_is_finite(left_residual)) &
+            .or. .not. all(ieee_is_finite(right_residual)) &
+            .or. .not. all(ieee_is_finite(left_scale)) &
+            .or. .not. all(ieee_is_finite(right_scale)) &
+            .or. any(compatibility_scale <= 0.0_real64) &
+            .or. any(dropped_p_scale <= 0.0_real64) &
+            .or. any(dropped_m_scale <= 0.0_real64) &
+            .or. any(left_scale <= 0.0_real64) &
+            .or. any(right_scale <= 0.0_real64) &
+            .or. any(source_scale <= 0.0_real64) &
+            .or. .not. all(ieee_is_finite(transfer_error))) then
+            ierr = 7
+            return
+        end if
+
+        open(newunit=iunit, file=join_end_output_filename, status='old', &
+            position='append', action='write', iostat=status)
+        if (status /= 0) then
+            ierr = 8
+            return
+        end if
+        join_end_record = join_end_record + 1
+        do force = 1, 3
+            call write_join_end_value(iunit, 'source_factor', -1, force, -1, &
+                source_factor(force), status)
+            call write_join_end_value(iunit, 'source_before', -1, force, -1, &
+                source_before(force), status)
+            call write_join_end_value(iunit, 'source_after', -1, force, -1, &
+                source_after(force), status)
+            call write_join_end_value(iunit, 'source_scale', -1, force, -1, &
+                source_scale(force), status)
+        end do
+        call write_join_end_value(iunit, 'measure_sum', -1, 0, -1, &
+            measure_sum, status)
+        call write_join_end_value(iunit, 'forward_identity', -1, 0, -1, &
+            transfer_error(1), status)
+        call write_join_end_value(iunit, 'backward_identity', -1, 0, -1, &
+            transfer_error(2), status)
+        do laguerre = 1, size(compatibility, 1)
+            do force = 1, 3
+                call write_join_end_value(iunit, 'compatibility', &
+                    laguerre - 1, force, -1, &
+                    compatibility(laguerre, force), status)
+                call write_join_end_value(iunit, 'compatibility_scale', &
+                    laguerre - 1, force, -1, &
+                    compatibility_scale(laguerre, force), status)
+                call write_join_end_value(iunit, 'dropped_p', laguerre - 1, &
+                    force, -1, dropped_p(laguerre, force), status)
+                call write_join_end_value(iunit, 'dropped_p_scale', &
+                    laguerre - 1, force, -1, &
+                    dropped_p_scale(laguerre, force), status)
+                call write_join_end_value(iunit, 'dropped_m', laguerre - 1, &
+                    force, -1, dropped_m(laguerre, force), status)
+                call write_join_end_value(iunit, 'dropped_m_scale', &
+                    laguerre - 1, force, -1, &
+                    dropped_m_scale(laguerre, force), status)
+                call write_join_end_value(iunit, 'dropped_difference', &
+                    laguerre - 1, force, -1, &
+                    dropped_p(laguerre, force) &
+                    - dropped_m(laguerre, force), status)
+            end do
+            call write_join_end_value(iunit, 'left_residual', laguerre - 1, &
+                0, -1, left_residual(laguerre), status)
+            call write_join_end_value(iunit, 'left_scale', laguerre - 1, &
+                0, -1, left_scale(laguerre), status)
+            call write_join_end_value(iunit, 'right_residual', laguerre - 1, &
+                0, -1, right_residual(laguerre), status)
+            call write_join_end_value(iunit, 'right_scale', laguerre - 1, &
+                0, -1, right_scale(laguerre), status)
+            do index = 1, size(left_null, 1)
+                call write_join_end_value(iunit, 'left_null', laguerre - 1, &
+                    0, index, left_null(index, laguerre), status)
+                call write_join_end_value(iunit, 'right_null', laguerre - 1, &
+                    0, index, right_null(index, laguerre), status)
+            end do
+        end do
+        close(iunit, iostat=ierr)
+        if (status /= 0 .or. ierr /= 0) ierr = 8
+    end subroutine record_join_end_compatibility
+
+    subroutine write_join_end_value(iunit, kind, laguerre, force, index, value, &
+            status)
+        integer, intent(in) :: iunit, laguerre, force, index
+        character(len=*), intent(in) :: kind
+        real(real64), intent(in) :: value
+        integer, intent(inout) :: status
+
+        if (status /= 0) return
+        join_end_sequence = join_end_sequence + 1
+        write(iunit, '(2(i0,","),a,",",3(i0,","),es25.16e3)', iostat=status) &
+            join_end_sequence, join_end_record, trim(kind), laguerre, force, &
+            index, value
+    end subroutine write_join_end_value
+
+    subroutine initialize_join_end_output(ierr)
+        integer, intent(out) :: ierr
+
+        integer :: iunit, length, status
+
+        ierr = 0
+        join_end_output_initialized = .true.
+        call get_environment_variable('NEO2_JOIN_END_TRACE_FILE', &
+            length=length, status=status)
+        if (status /= 0 .or. length == 0) return
+        allocate(character(len=length) :: join_end_output_filename)
+        call get_environment_variable('NEO2_JOIN_END_TRACE_FILE', &
+            value=join_end_output_filename, status=status)
+        if (status == 0) then
+            open(newunit=iunit, file=join_end_output_filename, &
+                status='replace', action='write', iostat=status)
+        end if
+        if (status == 0) then
+            write(iunit, '(a)', iostat=status) &
+                'sequence,join,kind,laguerre,force,index,value'
+            close(iunit, iostat=ierr)
+        end if
+        if (status /= 0) ierr = 8
+        if (ierr /= 0 .and. allocated(join_end_output_filename)) &
+            deallocate(join_end_output_filename)
+    end subroutine initialize_join_end_output
 end module join_diagnostics_mod

--- a/NEO-2-QL/join_ends.f90
+++ b/NEO-2-QL/join_ends.f90
@@ -23,6 +23,8 @@ SUBROUTINE join_ends(ierr)
   USE propagator_mod
   USE lapack_band
   USE collisionality_mod, ONLY : isw_lorentz
+  USE join_diagnostics_mod, ONLY : join_end_trace_enabled, &
+                                   record_join_end_compatibility
 
   IMPLICIT NONE
   INTEGER, PARAMETER :: dp = KIND(1.0d0)
@@ -34,7 +36,9 @@ SUBROUTINE join_ends(ierr)
 
 
   INTEGER :: ndim,i,i1,ntranseq,info,nl,nr,nts_r,nts_l,kl,kr,m,kr1,nvel
+  INTEGER :: idiag,jdiag,nconstraints,trace_info
   INTEGER,          DIMENSION(:),   ALLOCATABLE :: ipivot,iminvec,imaxvec
+  INTEGER,          DIMENSION(:),   ALLOCATABLE :: trace_pivot
 
   ! WINNY
   ! made it compatible with propagator_mod
@@ -49,6 +53,15 @@ SUBROUTINE join_ends(ierr)
   DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: alam_l,alam_r
 
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: amat,bvec_lapack,transmat
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: compatibility,dropped_p
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: dropped_m,left_null
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: compatibility_scale
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: dropped_p_scale
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: dropped_m_scale
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: right_null,periodic_matrix
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: periodic_rhs,trace_matrix
+  DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: left_residual,right_residual
+  DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: left_scale,right_scale
 
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: qflux,dqflux
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: source_m,dsource_m
@@ -61,9 +74,14 @@ SUBROUTINE join_ends(ierr)
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: amat_m_p,damat_m_p
   INTEGER :: ndupl,idupl
   DOUBLE PRECISION :: facnorm
+  DOUBLE PRECISION :: measure_sum,source_after(3),source_before(3)
+  DOUBLE PRECISION :: source_factor(3),source_scale(3),transfer_error(2)
+  LOGICAL :: trace_join_end
 
   ! initialize
   ierr = 0
+  trace_join_end = join_end_trace_enabled(ierr)
+  IF(ierr.NE.0) RETURN
   o => prop_c%prev
   n => prop_c
 
@@ -95,6 +113,39 @@ PRINT *,'nl,nr = ',nl,nr
   nts_l=nl*(nvel+1)
   nts_r=nr*(nvel+1)
 
+  IF(trace_join_end) THEN
+    source_factor=0.d0
+    source_before=SUM(o%p%source_p,DIM=1)+SUM(o%p%source_m,DIM=1)
+    source_scale=SUM(ABS(o%p%source_p),DIM=1) &
+                +SUM(ABS(o%p%source_m),DIM=1)
+    source_scale=MAX(source_scale,TINY(1.d0))
+    source_after=source_before
+    measure_sum=0.d0
+    transfer_error=0.d0
+    DO idiag=1,SIZE(c_forward,1)
+      DO jdiag=1,SIZE(c_forward,2)
+        IF(idiag.EQ.jdiag) THEN
+          transfer_error(1)=MAX(transfer_error(1), &
+                                ABS(c_forward(idiag,jdiag)-1.d0))
+        ELSE
+          transfer_error(1)=MAX(transfer_error(1), &
+                                ABS(c_forward(idiag,jdiag)))
+        ENDIF
+      ENDDO
+    ENDDO
+    DO idiag=1,SIZE(c_backward,1)
+      DO jdiag=1,SIZE(c_backward,2)
+        IF(idiag.EQ.jdiag) THEN
+          transfer_error(2)=MAX(transfer_error(2), &
+                                ABS(c_backward(idiag,jdiag)-1.d0))
+        ELSE
+          transfer_error(2)=MAX(transfer_error(2), &
+                                ABS(c_backward(idiag,jdiag)))
+        ENDIF
+      ENDDO
+    ENDDO
+  ENDIF
+
 
 ! Correction of sorce and flux symmetry due to Pfirsch-Schlueter current closure
 ! condition and asymmetry of electric drive (for Lorentz model only)
@@ -108,10 +159,13 @@ PRINT *,'nl,nr = ',nl,nr
     delta_eta_r(1:nr-1)=o%p%eta_r(1:nr-1)-o%p%eta_r(0:nr-2)
     delta_eta_r(nr) = o%p%eta_boundary_r - o%p%eta_r(nr-1)
 
+    IF(trace_join_end) measure_sum=SUM(delta_eta_l)+SUM(delta_eta_r)
+
     DO i=1,3
 
       facnorm=(SUM(o%p%source_p(:,i))+SUM(o%p%source_m(:,i)))          &
              *0.5d0/o%p%eta_boundary_r
+      IF(trace_join_end) source_factor(i)=facnorm
       o%p%source_p(:,i)=o%p%source_p(:,i)-delta_eta_r*facnorm
       o%p%source_m(:,i)=o%p%source_m(:,i)-delta_eta_l*facnorm
 
@@ -122,6 +176,9 @@ PRINT *,'nl,nr = ',nl,nr
       o%p%flux_m(i,:)=o%p%flux_m(i,:)-facnorm
 
     ENDDO
+
+    IF(trace_join_end) &
+      source_after=SUM(o%p%source_p,DIM=1)+SUM(o%p%source_m,DIM=1)
 
   ENDIF
 
@@ -282,6 +339,40 @@ CLOSE(111)
                      =MATMUL(c_backward,o%p%source_m(kl+1:kl+nl,1:3))
   ENDDO
 
+  IF(trace_join_end) THEN
+    nconstraints=1
+    IF(nvel.GT.0) nconstraints=2
+    ALLOCATE(periodic_matrix(ndim,ndim),periodic_rhs(ndim,ntranseq))
+    ALLOCATE(left_null(ndim,nconstraints),right_null(ndim,nconstraints))
+    ALLOCATE(compatibility(nconstraints,ntranseq))
+    ALLOCATE(dropped_p(nconstraints,ntranseq))
+    ALLOCATE(dropped_m(nconstraints,ntranseq))
+    ALLOCATE(compatibility_scale(nconstraints,ntranseq))
+    ALLOCATE(dropped_p_scale(nconstraints,ntranseq))
+    ALLOCATE(dropped_m_scale(nconstraints,ntranseq))
+    ALLOCATE(left_residual(nconstraints),right_residual(nconstraints))
+    ALLOCATE(left_scale(nconstraints),right_scale(nconstraints))
+    ALLOCATE(trace_matrix(ndim,ndim),trace_pivot(ndim))
+    periodic_matrix=amat
+    periodic_rhs=bvec_lapack
+    left_null=0.d0
+    DO m=0,nconstraints-1
+      left_null(m*nl+1:(m+1)*nl,m+1)=1.d0
+      left_null(nts_l+m*nr+1:nts_l+(m+1)*nr,m+1)=1.d0
+    ENDDO
+    compatibility=MATMUL(TRANSPOSE(left_null),periodic_rhs)
+    DO m=1,nconstraints
+      DO i=1,ntranseq
+        compatibility_scale(m,i)=MAX(SUM(ABS(periodic_rhs(:,i)) &
+                                      *ABS(left_null(:,m))),TINY(1.d0))
+      ENDDO
+      left_residual(m)=MAXVAL(ABS(MATMUL(TRANSPOSE(periodic_matrix), &
+                                       left_null(:,m))))
+      left_scale(m)=MAX(MAXVAL(MATMUL(TRANSPOSE(ABS(periodic_matrix)), &
+                                     ABS(left_null(:,m)))),TINY(1.d0))
+    ENDDO
+  ENDIF
+
 OPEN(751,file='amat_before.dat')
 OPEN(752,file='bvec_before.dat')
 DO i=1,ndim
@@ -305,6 +396,32 @@ if(nvel.gt.0) then
   amat(nts_l+2*nr,nts_l+nr+1:nts_l+2*nr)=1.d0
   bvec_lapack(nts_l+2*nr,:)=0.d0
 endif
+
+  IF(trace_join_end) THEN
+    trace_matrix=periodic_matrix
+    right_null=0.d0
+    trace_matrix(nts_l+nr,:)=0.d0
+    trace_matrix(nts_l+nr,1:nl)=1.d0
+    trace_matrix(nts_l+nr,nts_l+1:nts_l+nr)=1.d0
+    right_null(nts_l+nr,1)=1.d0
+    IF(nconstraints.GT.1) THEN
+      trace_matrix(nts_l+2*nr,:)=0.d0
+      trace_matrix(nts_l+2*nr,nl+1:2*nl)=1.d0
+      trace_matrix(nts_l+2*nr,nts_l+nr+1:nts_l+2*nr)=1.d0
+      right_null(nts_l+2*nr,2)=1.d0
+    ENDIF
+    CALL gbsv(ndim,ndim,trace_matrix,trace_pivot,right_null,trace_info)
+    IF(trace_info.NE.0) THEN
+      ierr=9
+      RETURN
+    ENDIF
+    DO m=1,nconstraints
+      right_residual(m)=MAXVAL(ABS(MATMUL(periodic_matrix, &
+                                        right_null(:,m))))
+      right_scale(m)=MAX(MAXVAL(MATMUL(ABS(periodic_matrix), &
+                                      ABS(right_null(:,m)))),TINY(1.d0))
+    ENDDO
+  ENDIF
 OPEN(751,file='amat_after.dat')
 OPEN(752,file='bvec_after.dat')
 DO i=1,ndim
@@ -318,6 +435,32 @@ CLOSE(752)
   IF(info.NE.0) THEN
     ierr=2
     RETURN
+  ENDIF
+
+  IF(trace_join_end) THEN
+    DO m=0,nconstraints-1
+      dropped_p(m+1,:)=MATMUL(periodic_matrix((m+1)*nl,:),bvec_lapack) &
+                       -periodic_rhs((m+1)*nl,:)
+      dropped_m(m+1,:)=MATMUL(periodic_matrix(nts_l+(m+1)*nr,:), &
+                              bvec_lapack) &
+                       -periodic_rhs(nts_l+(m+1)*nr,:)
+      DO i=1,ntranseq
+        dropped_p_scale(m+1,i)=MAX( &
+          DOT_PRODUCT(ABS(periodic_matrix((m+1)*nl,:)), &
+                      ABS(bvec_lapack(:,i))) &
+          +ABS(periodic_rhs((m+1)*nl,i)),TINY(1.d0))
+        dropped_m_scale(m+1,i)=MAX( &
+          DOT_PRODUCT(ABS(periodic_matrix(nts_l+(m+1)*nr,:)), &
+                      ABS(bvec_lapack(:,i))) &
+          +ABS(periodic_rhs(nts_l+(m+1)*nr,i)),TINY(1.d0))
+      ENDDO
+    ENDDO
+    CALL record_join_end_compatibility(source_factor,source_before, &
+         source_after,source_scale,measure_sum,compatibility,dropped_p, &
+         dropped_m,compatibility_scale,dropped_p_scale,dropped_m_scale, &
+         left_null,right_null,left_residual,right_residual,left_scale, &
+         right_scale,transfer_error,ierr)
+    IF(ierr.NE.0) RETURN
   ENDIF
 
 OPEN(752,file='bvec_solution.dat')

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -147,7 +147,7 @@ add_test(NAME join_failure_diagnostic_test
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 set_tests_properties(join_failure_diagnostic_test PROPERTIES
-    ENVIRONMENT "NEO2_JOIN_NORMALIZATION_FILE=${CMAKE_CURRENT_BINARY_DIR}/join_normalization.csv"
+    ENVIRONMENT "NEO2_JOIN_NORMALIZATION_FILE=${CMAKE_CURRENT_BINARY_DIR}/join_normalization.csv;NEO2_JOIN_END_TRACE_FILE=${CMAKE_CURRENT_BINARY_DIR}/join_end_trace.csv"
     PASS_REGULAR_EXPRESSION "join_ripples: DGBSV info=2"
     FAIL_REGULAR_EXPRESSION "FAIL"
     TIMEOUT 30

--- a/TEST/test_join_failure_diagnostic.f90
+++ b/TEST/test_join_failure_diagnostic.f90
@@ -1,16 +1,28 @@
 program test_join_failure_diagnostic
-    use join_diagnostics_mod, only: report_join_failure, &
+    use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
+    use join_diagnostics_mod, only: record_join_end_compatibility, &
+        report_join_failure, &
         validate_join_normalization
     use lapack_band, only: gbsv
     implicit none
 
-    real(kind(1.0d0)) :: matrix(2, 2), rhs(2, 1)
-    real(kind(1.0d0)) :: factor
+    real(kind(1.0d0)) :: bad_dropped(2, 3), compatibility(1, 3)
+    real(kind(1.0d0)) :: compatibility_scale(1, 3)
+    real(kind(1.0d0)) :: dropped_m(1, 3), dropped_p(1, 3), factor
+    real(kind(1.0d0)) :: dropped_m_scale(1, 3), dropped_p_scale(1, 3)
+    real(kind(1.0d0)) :: left_null(2, 1), left_residual(1), left_scale(1)
+    real(kind(1.0d0)) :: matrix(2, 2), measure_sum, rhs(2, 1)
+    real(kind(1.0d0)) :: right_null(2, 1), right_residual(1), right_scale(1)
+    real(kind(1.0d0)) :: source_after(3), source_before(3)
+    real(kind(1.0d0)) :: source_factor(3), source_scale(3), transfer_error(2)
+    real(kind(1.0d0)) :: value
     character(len=1024) :: filename
     character(len=128) :: header
+    character(len=32) :: record_kind
     character(len=1) :: direction
-    integer :: column, info, ierr, iunit, new_tags(2), old_tags(2), &
-        npass(2), pivot(2), sequence, status
+    integer :: column, force, index, info, ierr, iunit, join, laguerre, line_count
+    integer :: new_tags(2), old_tags(2), npass(2), pivot(2), sequence, status
+    logical :: found_right_null, found_source_factor
 
     matrix = reshape([1.0d0, 2.0d0, 2.0d0, 4.0d0], shape(matrix))
     rhs(:, 1) = [1.0d0, 2.0d0]
@@ -43,4 +55,80 @@ program test_join_failure_diagnostic
         .or. any(new_tags /= [13, 13]) .or. any(npass /= [24, 24]) &
         .or. factor /= 1.0d0) &
         error stop 'FAIL: join normalization record is wrong'
+
+    source_factor = [1.0d0, 2.0d0, 3.0d0]
+    source_before = [4.0d0, 5.0d0, 6.0d0]
+    source_after = [0.0d0, 0.0d0, 0.0d0]
+    source_scale = [25.0d0, 26.0d0, 27.0d0]
+    measure_sum = 2.0d0
+    compatibility = reshape([7.0d0, 8.0d0, 9.0d0], [1, 3])
+    dropped_p = reshape([10.0d0, 11.0d0, 12.0d0], [1, 3])
+    dropped_m = reshape([13.0d0, 14.0d0, 15.0d0], [1, 3])
+    compatibility_scale = 20.0d0
+    dropped_p_scale = 21.0d0
+    dropped_m_scale = 22.0d0
+    left_null(:, 1) = [1.0d0, 1.0d0]
+    right_null(:, 1) = [3.0d0, 4.0d0]
+    left_residual = [16.0d0]
+    right_residual = [17.0d0]
+    left_scale = [23.0d0]
+    right_scale = [24.0d0]
+    transfer_error = [18.0d0, 19.0d0]
+    call record_join_end_compatibility(source_factor, source_before, &
+        source_after, source_scale, measure_sum, compatibility, dropped_p, &
+        dropped_m, &
+        compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
+        right_null, left_residual, right_residual, left_scale, right_scale, &
+        transfer_error, ierr)
+    if (ierr /= 0) error stop 'FAIL: valid join-end trace was rejected'
+
+    bad_dropped = 0.0d0
+    call record_join_end_compatibility(source_factor, source_before, &
+        source_after, source_scale, measure_sum, compatibility, bad_dropped, &
+        dropped_m, &
+        compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
+        right_null, left_residual, right_residual, left_scale, right_scale, &
+        transfer_error, ierr)
+    if (ierr /= 7) error stop 'FAIL: invalid join-end shape was accepted'
+
+    source_scale(1) = ieee_value(0.0d0, ieee_quiet_nan)
+    call record_join_end_compatibility(source_factor, source_before, &
+        source_after, source_scale, measure_sum, compatibility, dropped_p, &
+        dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
+        left_null, right_null, left_residual, right_residual, left_scale, &
+        right_scale, transfer_error, ierr)
+    if (ierr /= 7) error stop 'FAIL: non-finite join-end value was accepted'
+    source_scale(1) = 25.0d0
+
+    call get_environment_variable('NEO2_JOIN_END_TRACE_FILE', filename)
+    open(newunit=iunit, file=trim(filename), status='old', action='read', &
+        iostat=status)
+    if (status /= 0) error stop 'FAIL: join-end trace is absent'
+    read(iunit, '(a)', iostat=status) header
+    if (status /= 0 .or. trim(header) /= &
+        'sequence,join,kind,laguerre,force,index,value') &
+        error stop 'FAIL: join-end trace header is wrong'
+    line_count = 0
+    found_right_null = .false.
+    found_source_factor = .false.
+    do
+        read(iunit, *, iostat=status) sequence, join, record_kind, laguerre, &
+            force, index, value
+        if (status < 0) exit
+        if (status > 0) error stop 'FAIL: malformed join-end trace row'
+        line_count = line_count + 1
+        if (sequence /= line_count) &
+            error stop 'FAIL: join-end trace sequence is wrong'
+        if (join /= 1) error stop 'FAIL: join-end trace join is wrong'
+        if (trim(record_kind) == 'source_factor' .and. force == 2) then
+            found_source_factor = value == 2.0d0
+        end if
+        if (trim(record_kind) == 'right_null' .and. index == 2) then
+            found_right_null = value == 4.0d0
+        end if
+    end do
+    close(iunit)
+    if (line_count /= 44 .or. .not. found_source_factor &
+        .or. .not. found_right_null) &
+        error stop 'FAIL: join-end trace content is wrong'
 end program test_join_failure_diagnostic


### PR DESCRIPTION
`join_ends` replaces one periodic equation per retained Laguerre block with the Lorentz current-closure constraint. The remaining periodic seam could therefore have come from an incompatible source, an incorrect nullspace, or reconstruction of a different source.

Add an opt-in `NEO2_JOIN_END_TRACE_FILE` diagnostic. For each join it records the Lorentz source correction, transfer-matrix identity error, original periodic-system left and right null vectors, compatibility residual, both replaced-row residuals, and algebraic scales. The CSV writer rejects wrong shapes, nonfinite values, nonpositive scales, and I/O failures.

The diagnostic is observation-only. When disabled it allocates no diagnostic arrays and performs no diagnostic solve. It does not change the Lorentz projection, Pfirsch-Schlueter current constraint, particle-conservation treatment, collision operator, discretization, convergence criteria, Fourier convention, CGS units, boundary conditions, ABI, or array layout.

The accepted 480-step, 30-pitch batch replay resolves the open hypothesis:

- periodic compatibility residual: `2.81e-17` relative;
- replaced p/m row residuals: `1.18e-14` and `1.17e-14` relative;
- replaced-row difference: `1.39e-16` relative;
- left/right null residuals: `1.39e-16` and `5.27e-15` relative;
- Lorentz projection identity residual: `2.71e-16` relative;
- Lorentz source correction: `7.85e-4` of the unsigned source scale;
- periodic reconstructed-distribution seam: `7.28e-4`;
- periodic current-contraction seam: `8.48e-4`.

The periodic solve is compatible and satisfies both original rows. The seam instead follows from applying the Lorentz correction only to the joined propagator source. Stage-1 reconstruction replays the saved local sources, which do not contain a spatially localized form of that correction. This PR does not invent such a localization and does not accept a physical pointwise current.

With the diagnostic enabled, all 398 saved propagators and 199 reconstructed boundaries are bit-for-bit identical to the parent result. Every numerical dataset in the 199 local-response HDF5 files and the global response file is also identical. All 12 focused tests and the trace-analysis test pass under bounds checks and floating-point traps. A follow-up commit separates finiteness and positivity checks because Fortran logical operators are not required to short-circuit; this prevents a nonfinite diagnostic scale from reaching an ordered comparison under invalid-operation traps.

## Verification

### Test fails on parent

At `130ea2c`:

```text
rm -f build/TEST/join_end_trace.csv
fo test join_failure_diagnostic_test
test -s build/TEST/join_end_trace.csv

join_failure_diagnostic_test PASS
focused_test_status=0
trace_file_status=1
```

The existing test passes, but no requested join-end trace is produced.

### Test passes after fix

```text
rm -f build/TEST/join_end_trace.csv
fo test join_failure_diagnostic_test
test -s build/TEST/join_end_trace.csv

join_failure_diagnostic_test PASS
focused_test_status=0
trace_file_status=0
```

```text
fo

Static: OK
Build: OK
Tests: OK
Lint: OK
Fmt: WARN
All stages passed
```

The format warning is already present for the legacy `join_ends.f90` file at the parent commit. This PR keeps its existing layout instead of reformatting unrelated lines.
