### PR TITLE
Diagnose local Lorentz projector compatibility

### DIFF
--- a/NEO-2-QL/CMakeSources.in
+++ b/NEO-2-QL/CMakeSources.in
@@ -10,6 +10,7 @@ set(NEO2_QL_SRC_FILES
   ripple_solver_axi_test.f90
   ripple_solver_ArnoldiOrder2_test.f90
   join_diagnostics_mod.f90
+  lorentz_projection_diagnostics_mod.f90
   join_ripples_int.f90
   join_ripples.f90
   join_ends.f90

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -1,0 +1,242 @@
+module lorentz_projection_diagnostics_mod
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use, intrinsic :: iso_fortran_env, only: real64
+    implicit none
+    private
+
+    type, public :: local_projection_residuals
+        real(real64) :: source_defect(3)
+        real(real64) :: source_scale(3)
+        real(real64) :: flux_null(3)
+        real(real64) :: flux_scale(3)
+        real(real64) :: measure
+        real(real64) :: left_transport
+        real(real64) :: left_scale
+        real(real64) :: right_transport
+        real(real64) :: right_scale
+        real(real64) :: intertwining
+        real(real64) :: intertwining_scale
+    end type local_projection_residuals
+
+    character(len=:), allocatable, save :: output_filename
+    integer, save :: record_sequence = 0
+    logical, save :: output_initialized = .false.
+
+    public :: compute_local_projection_residuals
+    public :: record_local_projection_residuals
+
+contains
+
+    subroutine compute_local_projection_residuals(source_p, source_m, flux_p, &
+            flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
+            eta_boundary_l, eta_boundary_r, residuals, ierr)
+        real(real64), intent(in) :: source_p(:, :), source_m(:, :)
+        real(real64), intent(in) :: flux_p(:, :), flux_m(:, :)
+        real(real64), intent(in) :: amat_p_p(:, :), amat_m_p(:, :)
+        real(real64), intent(in) :: amat_p_m(:, :), amat_m_m(:, :)
+        real(real64), intent(in) :: eta_l(0:), eta_r(0:)
+        real(real64), intent(in) :: eta_boundary_l, eta_boundary_r
+        type(local_projection_residuals), intent(out) :: residuals
+        integer, intent(out) :: ierr
+
+        real(real64), allocatable :: matrix(:, :), weights_in(:), weights_out(:)
+        real(real64), allocatable :: applied_weights(:), column_sum(:)
+        real(real64), allocatable :: intertwining_matrix(:, :)
+        integer :: nl, nr, ndim
+
+        nl = size(amat_p_p, 2)
+        nr = size(amat_p_p, 1)
+        call validate_shapes(nl, nr, source_p, source_m, flux_p, flux_m, &
+            amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, ierr)
+        if (ierr /= 0) return
+        ndim = nl + nr
+        allocate(matrix(ndim, ndim), weights_in(ndim), weights_out(ndim))
+        allocate(applied_weights(ndim), column_sum(ndim))
+        call assemble_map(matrix, amat_p_p, amat_m_p, amat_p_m, amat_m_m, nl, nr)
+        call assemble_weights(weights_in, weights_out, eta_l, eta_r, &
+            eta_boundary_l, eta_boundary_r, nl, nr, ierr)
+        if (ierr /= 0) return
+        residuals%measure = sum(weights_out)
+        applied_weights = matmul(matrix, weights_in)
+        column_sum = sum(matrix, dim=1)
+        residuals%source_defect = sum(source_p, dim=1) + sum(source_m, dim=1)
+        residuals%source_scale = max(sum(abs(source_p), dim=1) + &
+            sum(abs(source_m), dim=1), tiny(1.0_real64))
+        residuals%flux_null = matmul(flux_p, weights_in(1:nl)) + &
+            matmul(flux_m, weights_in(nl + 1:ndim))
+        residuals%flux_scale = max(matmul(abs(flux_p), abs(weights_in(1:nl))) + &
+            matmul(abs(flux_m), abs(weights_in(nl + 1:ndim))), tiny(1.0_real64))
+        residuals%left_transport = maxval(abs(column_sum - 1.0_real64))
+        residuals%left_scale = max(maxval(sum(abs(matrix), dim=1) + 1.0_real64), &
+            tiny(1.0_real64))
+        residuals%right_transport = maxval(abs(applied_weights - weights_out))
+        residuals%right_scale = max(maxval(matmul(abs(matrix), abs(weights_in)) + &
+            abs(weights_out)), tiny(1.0_real64))
+        allocate(intertwining_matrix(ndim, ndim))
+        intertwining_matrix = (spread(applied_weights, 2, ndim) - &
+            spread(weights_out, 2, ndim)*spread(column_sum, 1, ndim)) &
+            /residuals%measure
+        residuals%intertwining = maxval(abs(intertwining_matrix))
+        residuals%intertwining_scale = max(maxval((spread(abs(applied_weights), &
+            2, ndim) + spread(abs(weights_out), 2, ndim)* &
+            spread(abs(column_sum), 1, ndim))/residuals%measure), &
+            tiny(1.0_real64))
+        ierr = 0
+    end subroutine compute_local_projection_residuals
+
+    subroutine validate_shapes(nl, nr, source_p, source_m, flux_p, flux_m, &
+            amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, ierr)
+        integer, intent(in) :: nl, nr
+        real(real64), intent(in) :: source_p(:, :), source_m(:, :)
+        real(real64), intent(in) :: flux_p(:, :), flux_m(:, :)
+        real(real64), intent(in) :: amat_m_p(:, :), amat_p_m(:, :)
+        real(real64), intent(in) :: amat_m_m(:, :), eta_l(0:), eta_r(0:)
+        integer, intent(out) :: ierr
+
+        ierr = 1
+        if (nl < 1 .or. nr < 1) return
+        if (size(source_p, 1) /= nr .or. size(source_m, 1) /= nl) return
+        if (size(source_p, 2) /= 3 .or. size(source_m, 2) /= 3) return
+        if (size(flux_p, 1) /= 3 .or. size(flux_p, 2) /= nl) return
+        if (size(flux_m, 1) /= 3 .or. size(flux_m, 2) /= nr) return
+        if (any(shape(amat_m_p) /= [nr, nr])) return
+        if (any(shape(amat_p_m) /= [nl, nl])) return
+        if (any(shape(amat_m_m) /= [nl, nr])) return
+        if (size(eta_l) < nl .or. size(eta_r) < nr) return
+        ierr = 0
+    end subroutine validate_shapes
+
+    subroutine assemble_map(matrix, amat_p_p, amat_m_p, amat_p_m, amat_m_m, &
+            nl, nr)
+        real(real64), intent(out) :: matrix(:, :)
+        real(real64), intent(in) :: amat_p_p(:, :), amat_m_p(:, :)
+        real(real64), intent(in) :: amat_p_m(:, :), amat_m_m(:, :)
+        integer, intent(in) :: nl, nr
+
+        matrix(1:nr, 1:nl) = amat_p_p
+        matrix(1:nr, nl + 1:nl + nr) = amat_m_p
+        matrix(nr + 1:nr + nl, 1:nl) = amat_p_m
+        matrix(nr + 1:nr + nl, nl + 1:nl + nr) = amat_m_m
+    end subroutine assemble_map
+
+    subroutine assemble_weights(weights_in, weights_out, eta_l, eta_r, &
+            eta_boundary_l, eta_boundary_r, nl, nr, ierr)
+        real(real64), intent(out) :: weights_in(:), weights_out(:)
+        real(real64), intent(in) :: eta_l(0:), eta_r(0:)
+        real(real64), intent(in) :: eta_boundary_l, eta_boundary_r
+        integer, intent(in) :: nl, nr
+        integer, intent(out) :: ierr
+        real(real64), allocatable :: weights_l(:), weights_r(:)
+
+        allocate(weights_l(nl), weights_r(nr))
+        call boundary_weights(eta_l, eta_boundary_l, weights_l, ierr)
+        if (ierr /= 0) return
+        call boundary_weights(eta_r, eta_boundary_r, weights_r, ierr)
+        if (ierr /= 0) return
+        weights_in = [weights_l, weights_r]
+        weights_out = [weights_r, weights_l]
+    end subroutine assemble_weights
+
+    subroutine boundary_weights(eta, eta_boundary, weights, ierr)
+        real(real64), intent(in) :: eta(0:), eta_boundary
+        real(real64), intent(out) :: weights(:)
+        integer, intent(out) :: ierr
+        integer :: n
+
+        n = size(weights)
+        if (n > 1) weights(1:n - 1) = eta(1:n - 1) - eta(0:n - 2)
+        weights(n) = eta_boundary - eta(n - 1)
+        ierr = 0
+        if (.not. all(ieee_is_finite(weights)) .or. &
+            .not. ieee_is_finite(eta_boundary)) ierr = 2
+        if (ierr == 0 .and. any(weights <= 0.0_real64)) ierr = 2
+    end subroutine boundary_weights
+
+    subroutine record_local_projection_residuals(tag, source_p, source_m, &
+            flux_p, flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, &
+            eta_r, eta_boundary_l, eta_boundary_r, ierr)
+        integer, intent(in) :: tag
+        real(real64), intent(in) :: source_p(:, :), source_m(:, :)
+        real(real64), intent(in) :: flux_p(:, :), flux_m(:, :)
+        real(real64), intent(in) :: amat_p_p(:, :), amat_m_p(:, :)
+        real(real64), intent(in) :: amat_p_m(:, :), amat_m_m(:, :)
+        real(real64), intent(in) :: eta_l(0:), eta_r(0:)
+        real(real64), intent(in) :: eta_boundary_l, eta_boundary_r
+        integer, intent(out) :: ierr
+        type(local_projection_residuals) :: residuals
+        integer :: force, iunit, status
+
+        call initialize_output(ierr)
+        if (ierr /= 0 .or. .not. allocated(output_filename)) return
+        call compute_local_projection_residuals(source_p, source_m, flux_p, &
+            flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
+            eta_boundary_l, eta_boundary_r, residuals, ierr)
+        if (ierr /= 0) return
+        open(newunit=iunit, file=output_filename, status='old', position='append', &
+            action='write', iostat=status)
+        if (status /= 0) then
+            ierr = 3
+            return
+        end if
+        do force = 1, 3
+            call write_value(iunit, tag, 'source_defect', force, &
+                residuals%source_defect(force), residuals%source_scale(force), status)
+            call write_value(iunit, tag, 'flux_null', force, &
+                residuals%flux_null(force), residuals%flux_scale(force), status)
+        end do
+        call write_value(iunit, tag, 'left_transport', -1, &
+            residuals%left_transport, residuals%left_scale, status)
+        call write_value(iunit, tag, 'right_transport', -1, &
+            residuals%right_transport, residuals%right_scale, status)
+        call write_value(iunit, tag, 'intertwining', -1, residuals%intertwining, &
+            residuals%intertwining_scale, status)
+        call write_value(iunit, tag, 'measure', -1, residuals%measure, &
+            max(abs(residuals%measure), tiny(1.0_real64)), status)
+        close(iunit, iostat=ierr)
+        if (status /= 0 .or. ierr /= 0) ierr = 3
+    end subroutine record_local_projection_residuals
+
+    subroutine write_value(iunit, tag, kind, index, value, scale, status)
+        integer, intent(in) :: iunit, tag, index
+        character(len=*), intent(in) :: kind
+        real(real64), intent(in) :: value, scale
+        integer, intent(inout) :: status
+
+        if (status /= 0) return
+        if (.not. ieee_is_finite(value) .or. .not. ieee_is_finite(scale)) then
+            status = 1
+            return
+        end if
+        if (scale <= 0.0_real64) then
+            status = 1
+            return
+        end if
+        record_sequence = record_sequence + 1
+        write(iunit, '(i0,",",i0,",",a,",",i0,2(",",es25.16e3))', &
+            iostat=status) record_sequence, tag, trim(kind), index, value, scale
+    end subroutine write_value
+
+    subroutine initialize_output(ierr)
+        integer, intent(out) :: ierr
+        integer :: iunit, length, status
+
+        ierr = 0
+        if (output_initialized) return
+        output_initialized = .true.
+        call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
+            length=length, status=status)
+        if (status /= 0 .or. length == 0) return
+        allocate(character(len=length) :: output_filename)
+        call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
+            value=output_filename, status=status)
+        if (status == 0) open(newunit=iunit, file=output_filename, &
+            status='replace', action='write', iostat=status)
+        if (status == 0) then
+            write(iunit, '(a)', iostat=status) &
+                'sequence,propagator,kind,index,value,scale'
+            close(iunit, iostat=ierr)
+        end if
+        if (status /= 0 .or. ierr /= 0) ierr = 3
+        if (ierr /= 0 .and. allocated(output_filename)) deallocate(output_filename)
+    end subroutine initialize_output
+end module lorentz_projection_diagnostics_mod

--- a/NEO-2-QL/propagator.f90
+++ b/NEO-2-QL/propagator.f90
@@ -1064,7 +1064,9 @@ CONTAINS
          phi_split_min,hphi_mult,max_solver_try
     !! Modifications by Andreas F. Martitsch (15.03.2017)
     ! new: add exchange y-vector between ntv_mod and propagator_mod
-    USE collisionality_mod, ONLY : isw_axisymm, y_axi_averages
+    USE collisionality_mod, ONLY : isw_axisymm, isw_lorentz, y_axi_averages
+    USE lorentz_projection_diagnostics_mod, ONLY : &
+         record_local_projection_residuals
     USE ntv_mod, ONLY : y_ntv_mod
     !! End Modifications by Andreas F. Martitsch (15.03.2017)
     USE mag_interface_mod, ONLY : magnetic_device,mag_magfield
@@ -1328,6 +1330,15 @@ CONTAINS
        ! write eta at boundaries - replaced by modified stuff
        prop_c%p%eta_boundary_l = eta_modboundary_l
        prop_c%p%eta_boundary_r = eta_modboundary_r
+       IF (isw_lorentz .EQ. 1) THEN
+          CALL record_local_projection_residuals(fieldpropagator%tag, &
+               prop_c%p%source_p,prop_c%p%source_m,prop_c%p%flux_p, &
+               prop_c%p%flux_m,prop_c%p%amat_p_p,prop_c%p%amat_m_p, &
+               prop_c%p%amat_p_m,prop_c%p%amat_m_m,prop_c%p%eta_l, &
+               prop_c%p%eta_r,prop_c%p%eta_boundary_l, &
+               prop_c%p%eta_boundary_r,ierr_join)
+          IF (ierr_join .NE. 0) RETURN
+       END IF
        ! link actual to current (mainly for results and diagnostic)
        prop_a => prop_c
        ! writing of propagators

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -153,6 +153,21 @@ set_tests_properties(join_failure_diagnostic_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_lorentz_projection_diagnostic
+    test_lorentz_projection_diagnostic.f90)
+target_link_libraries(test_lorentz_projection_diagnostic neo2_ql)
+
+add_test(NAME lorentz_projection_diagnostic_test
+         COMMAND test_lorentz_projection_diagnostic
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(lorentz_projection_diagnostic_test PROPERTIES
+    ENVIRONMENT "NEO2_LOCAL_PROJECTION_TRACE_FILE=${CMAKE_CURRENT_BINARY_DIR}/local_projection_trace.csv"
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_qflux_interface_diagnostic test_qflux_interface_diagnostic.f90)
 target_link_libraries(test_qflux_interface_diagnostic neo2_ql)
 

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -1,0 +1,70 @@
+program test_lorentz_projection_diagnostic
+    use, intrinsic :: iso_fortran_env, only: real64
+    use lorentz_projection_diagnostics_mod, only: &
+        compute_local_projection_residuals, local_projection_residuals, &
+        record_local_projection_residuals
+    implicit none
+
+    real(real64) :: source_p(1, 3), source_m(1, 3)
+    real(real64) :: flux_p(3, 1), flux_m(3, 1)
+    real(real64) :: amat_p_p(1, 1), amat_m_p(1, 1)
+    real(real64) :: amat_p_m(1, 1), amat_m_m(1, 1)
+    real(real64) :: eta_l(0:0), eta_r(0:0)
+    type(local_projection_residuals) :: residuals
+    character(len=1024) :: filename, line
+    integer :: ierr, iunit, line_count, status
+
+    source_p = reshape([1.0_real64, 2.0_real64, 3.0_real64], [1, 3])
+    source_m = reshape([-0.5_real64, -1.0_real64, -1.5_real64], [1, 3])
+    flux_p = reshape([2.0_real64, 3.0_real64, 4.0_real64], [3, 1])
+    flux_m = reshape([-1.0_real64, -2.0_real64, -3.0_real64], [3, 1])
+    amat_p_p = 0.0_real64
+    amat_m_m = 0.0_real64
+    amat_m_p = 1.0_real64
+    amat_p_m = 1.0_real64
+    eta_l = 0.0_real64
+    eta_r = 0.0_real64
+
+    call compute_local_projection_residuals(source_p, source_m, flux_p, flux_m, &
+        amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, 0.4_real64, &
+        0.6_real64, residuals, ierr)
+    if (ierr /= 0) error stop 'FAIL: valid projection residual input rejected'
+    if (maxval(abs(residuals%source_defect - [0.5_real64, 1.0_real64, &
+        1.5_real64])) > 1.0e-15_real64) &
+        error stop 'FAIL: source defect is incorrect'
+    if (maxval(abs(residuals%flux_null - [0.2_real64, 0.0_real64, &
+        -0.2_real64])) > 1.0e-15_real64) &
+        error stop 'FAIL: flux null contraction is incorrect'
+    if (residuals%measure /= 1.0_real64) &
+        error stop 'FAIL: boundary measure is incorrect'
+    if (residuals%left_transport /= 0.0_real64) &
+        error stop 'FAIL: conservative left transport was not recognized'
+    if (residuals%right_transport /= 0.0_real64) &
+        error stop 'FAIL: null-vector transport was not recognized'
+    if (residuals%intertwining /= 0.0_real64) &
+        error stop 'FAIL: projector intertwining was not recognized'
+
+    call record_local_projection_residuals(7, source_p, source_m, flux_p, &
+        flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
+        0.4_real64, 0.6_real64, ierr)
+    if (ierr /= 0) error stop 'FAIL: projection trace was not written'
+    call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
+        value=filename, status=status)
+    if (status /= 0) error stop 'FAIL: projection trace path is absent'
+    open (newunit=iunit, file=trim(filename), status='old', action='read')
+    line_count = 0
+    do
+        read (iunit, '(a)', iostat=status) line
+        if (status /= 0) exit
+        line_count = line_count + 1
+    end do
+    close (iunit)
+    if (line_count /= 11) error stop 'FAIL: projection trace row count differs'
+
+    call compute_local_projection_residuals(source_p, source_m, flux_p, flux_m, &
+        amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, -0.4_real64, &
+        0.6_real64, residuals, ierr)
+    if (ierr == 0) error stop 'FAIL: nonpositive boundary weight accepted'
+
+    print *, 'All tests passed!'
+end program test_lorentz_projection_diagnostic


### PR DESCRIPTION
## Summary

Add an opt-in, observation-only diagnostic for testing whether the existing global Lorentz solvability projector can be moved to individual local propagators.

For a local boundary map \(A_k\), incoming and outgoing constant-distribution band vectors \(w_\mathrm{in}\) and \(w_\mathrm{out}\), and the particle invariant \(e^T\), endpoint projectors can commute with propagation only if

\[
e_\mathrm{out}^T A_k=e_\mathrm{in}^T,
\qquad
A_k w_\mathrm{in}=w_\mathrm{out},
\qquad
P_\mathrm{out}A_k=A_kP_\mathrm{in}.
\]

The diagnostic records these residuals, the local source compatibility defect, and the flux contraction with the constant-distribution direction. It runs only when `NEO2_LOCAL_PROJECTION_TRACE_FILE` is set and otherwise returns before allocation. This PR is stacked on #161. It does not apply a projector or change a numerical result.

## Why the constant-distribution vector is fixed

`DOC/ripple_solver_normalizations_and_output.tex` identifies each stored pitch unknown as

\[
Y_k=\int_{\eta_{k-1}}^{\eta_k} f\,d\eta.
\]

Consequently, a pitch-independent distribution is represented by the band widths, including the truncated final band at \(\eta=1/B\). This is the discrete target supplied by the continuous Lorentz gauge; it is not a fitted numerical null vector.

The continuous Fredholm calculation has since established the following constraints on the interpretation of this diagnostic:

- constant \(f\) is the right gauge of the monoenergetic Lorentz equation;
- collisional pitch flux vanishes at \(\eta=0\) and \(\eta=1/B\);
- moving mirror-boundary terms cancel between the two signs of parallel velocity;
- periodic streaming integrates to zero;
- the parallel-electric drive is sign-odd and compatible;
- the axisymmetric radial drive reduces, after pitch integration, to a periodic Boozer total derivative and is globally compatible;
- the finite global `join_ends` source correction is therefore a numerical compatibility repair that should converge to zero, not an additional physical Pfirsch-Schlueter source.

## Result

The 480-step Lorentz reconstruction contains 199 local propagators. The measured maxima are:

- left-invariant transport: \(5.88\times10^{-15}\);
- constant-distribution transport: \(1.8403\times10^{-3}\);
- projector intertwining: \(1.8404\times10^{-3}\).

The latter two residuals exceed \(10^{-12}\) in 139 of 199 propagators. A stage-0 spatial scan at fixed `eta_part=30` gives \(3.58\times10^{-3}\), \(1.84\times10^{-3}\), and \(6.69\times10^{-4}\) at 240, 480, and 960 spatial steps. The 240-step run contains solver recoveries, the 960-step value is diagnostic only, and a 60-pitch attempt failed bounds checks before producing physics evidence. The trend suggests a converging spatial consistency error but does not establish its order.

The call site is decisive: the trace is written immediately after each single-ripple solve, before adaptive pitch transfer, `join_ripples`, its Lorentz column normalization, and `join_ends`. The pinned final-end transfer matrices are exactly identity. The defect therefore enters in one of three places:

1. the single-ripple sparse discretization, including moving mirror matching;
2. the sparse solve of the basis columns;
3. extraction of those columns into the four boundary-map blocks.

The signed local source-defect sums for forces 1 and 3 reproduce the global pre-projection defects to reported precision; force 2 is cancellation dominated. Global compatibility alone does not determine a unique local affine-source correction, and a rank-one map repair is also non-unique. No operator change follows from this PR.

## Next diagnostic

Evaluate the assembled single-ripple sparse equations on the exact constant-\(f\) state at every internal spatial point, before factorization. Then compare:

1. the sparse-equation residual;
2. the solved basis-column combination for constant boundary data;
3. the extracted boundary map applied to the same band vector;
4. the same residual before and after later pitch transfer and column normalization as controls.

If the first residual is nonzero, the fault is in the discretization or mirror matching. If it is zero but the second is not, the sparse solve is responsible. If the second closes and the third does not, map extraction is responsible. Only this evidence, followed by a failure-free multidimensional convergence campaign, can justify a numerical correction.

## Preserved invariants

The change is diagnostic only. It leaves unchanged:

- the Lorentz collision operator, particle conservation, and physical sources;
- the discretization, sparse-solver criteria, and reconstruction order;
- Fourier convention, CGS units, and periodic/mirror boundary conditions;
- ABI, serialized propagator layout, and generated physics data.

With tracing enabled and disabled, all 596 matching local propagator files and all 199 reconstruction propagators were byte-identical. The local-response and reconstruction summaries were identical. All local HDF5 response files and the final transport/current files were equal under `h5diff`; configuration differences were limited to run metadata.

## Verification

Failing before:

```text
Test project .../build
No tests were found!!!
Errors while running CTest
```

Passing after:

```text
lorentz_projection_diagnostic_test PASS 0.07s
Summary: 1 passed, 0 failed, 0 skipped
join_failure_diagnostic_test PASS 0.07s
Summary: 1 passed, 0 failed, 0 skipped
Static: OK
Build: OK
Tests: OK
Lint: OK
Fmt: WARN (legacy propagator.f90)
All stages passed
```

The build and tests used bounds checks, backtraces, debug optimization, and floating-point traps for invalid, division-by-zero, and overflow operations.
