### PR TITLE
Trace local Lorentz constant state

### DIFF
--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -316,24 +316,33 @@ contains
     end subroutine record_local_constant_stage_residuals
 
     subroutine record_local_constant_row(tag, row, irow, icol, values, state, &
-            rhs, ierr)
+            rhs, npl, ind_start, bhat, ibeg, iend, lag, ierr)
         integer, intent(in) :: tag, row, irow(:), icol(:)
         real(real64), intent(in) :: values(:), state(:), rhs(:)
+        integer, intent(in) :: npl(ibeg:), ind_start(ibeg:)
+        real(real64), intent(in) :: bhat(ibeg:)
+        integer, intent(in) :: ibeg, iend, lag
         integer, intent(out) :: ierr
         character(len=:), allocatable :: filename
-        integer :: entry, iunit, status
+        integer :: column_band, column_laguerre, column_sigma, column_step
+        integer :: entry, iunit, row_band, row_laguerre, row_sigma, row_step, status
 
         ierr = 1
         if (.not. allocated(output_filename)) return
         if (size(irow) /= size(icol) .or. size(irow) /= size(values)) return
         if (row < 1 .or. row > size(state) .or. size(rhs) /= size(state)) return
+        call decode_state_index(row, npl, ind_start, ibeg, iend, lag, &
+            row_step, row_laguerre, row_sigma, row_band, status)
+        if (status /= 0) return
         filename = output_filename//'.rows'
         status = 0
         if (.not. row_output_initialized) then
             open(newunit=iunit, file=filename, status='replace', action='write', &
                 iostat=status)
             if (status == 0) write(iunit, '(a)', iostat=status) &
-                'propagator,row,column,coefficient,state,contribution,rhs'
+                'propagator,row,row_step,row_laguerre,row_sigma,row_band,'// &
+                'column,column_step,column_laguerre,column_sigma,column_band,'// &
+                'column_bhat,coefficient,state,contribution,rhs'
             if (status == 0) close(iunit, iostat=status)
             if (status /= 0) return
             row_output_initialized = .true.
@@ -343,15 +352,49 @@ contains
         if (status /= 0) return
         do entry = 1, size(values)
             if (irow(entry) /= row) cycle
-            write(iunit, '(i0,",",i0,",",i0,4(",",es25.16e3))', &
-                iostat=status) &
-                tag, row, icol(entry), values(entry), state(icol(entry)), &
-                values(entry)*state(icol(entry)), rhs(row)
+            call decode_state_index(icol(entry), npl, ind_start, ibeg, iend, &
+                lag, column_step, column_laguerre, column_sigma, column_band, &
+                status)
+            if (status /= 0) exit
+            write(iunit, '(11(i0,","),5(es25.16e3,:,","))', iostat=status) &
+                tag, row, row_step, row_laguerre, row_sigma, row_band, &
+                icol(entry), column_step, column_laguerre, column_sigma, &
+                column_band, bhat(column_step), values(entry), &
+                state(icol(entry)), values(entry)*state(icol(entry)), rhs(row)
             if (status /= 0) exit
         end do
         close(iunit, iostat=ierr)
         if (status /= 0 .or. ierr /= 0) ierr = 3
     end subroutine record_local_constant_row
+
+    subroutine decode_state_index(index, npl, ind_start, ibeg, iend, lag, &
+            step, laguerre, sigma, band, ierr)
+        integer, intent(in) :: index, npl(ibeg:), ind_start(ibeg:)
+        integer, intent(in) :: ibeg, iend, lag
+        integer, intent(out) :: step, laguerre, sigma, band, ierr
+        integer :: block_size, local_index, nbands, within_block
+
+        ierr = 1
+        if (index < 1 .or. lag < 0 .or. ibeg > iend) return
+        step = ibeg
+        do while (step < iend .and. index > ind_start(step + 1))
+            step = step + 1
+        end do
+        nbands = npl(step) + 1
+        block_size = 2*nbands
+        local_index = index - ind_start(step) - 1
+        if (local_index < 0 .or. local_index >= (lag + 1)*block_size) return
+        laguerre = local_index/block_size
+        within_block = mod(local_index, block_size)
+        if (within_block < nbands) then
+            sigma = 1
+            band = within_block + 1
+        else
+            sigma = -1
+            band = 2*nbands - within_block
+        end if
+        ierr = 0
+    end subroutine decode_state_index
 
     subroutine write_value(iunit, tag, kind, index, value, scale, status)
         integer, intent(in) :: iunit, tag, index

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -80,10 +80,11 @@ contains
     end subroutine assemble_local_constant_state
 
     subroutine compute_sparse_constant_residual(irow, icol, values, state, rhs, &
-            residual, scale, ierr)
+            residual, scale, residual_index, ierr)
         integer, intent(in) :: irow(:), icol(:)
         real(real64), intent(in) :: values(:), state(:), rhs(:)
         real(real64), intent(out) :: residual, scale
+        integer, intent(out) :: residual_index
         integer, intent(out) :: ierr
         real(real64), allocatable :: row_residual(:), row_scale(:)
         integer :: entry
@@ -102,8 +103,9 @@ contains
             row_scale(irow(entry)) = row_scale(irow(entry)) + &
                 abs(values(entry))*abs(state(icol(entry)))
         end do
-        residual = maxval(abs(row_residual))
-        scale = max(maxval(row_scale), tiny(1.0_real64))
+        residual_index = maxloc(abs(row_residual), dim=1)
+        residual = row_residual(residual_index)
+        scale = max(row_scale(residual_index), tiny(1.0_real64))
         ierr = 0
     end subroutine compute_sparse_constant_residual
 
@@ -277,8 +279,9 @@ contains
     end subroutine record_local_projection_residuals
 
     subroutine record_local_constant_stage_residuals(tag, sparse_residual, &
-            sparse_scale, solve_residual, solve_scale, ierr)
-        integer, intent(in) :: tag
+            sparse_scale, sparse_index, solve_residual, solve_scale, &
+            solve_index, ierr)
+        integer, intent(in) :: tag, sparse_index, solve_index
         real(real64), intent(in) :: sparse_residual, sparse_scale
         real(real64), intent(in) :: solve_residual, solve_scale
         integer, intent(out) :: ierr
@@ -292,10 +295,10 @@ contains
             ierr = 3
             return
         end if
-        call write_value(iunit, tag, 'sparse_constant', -1, sparse_residual, &
-            sparse_scale, status)
-        call write_value(iunit, tag, 'solved_constant', -1, solve_residual, &
-            solve_scale, status)
+        call write_value(iunit, tag, 'sparse_constant', sparse_index, &
+            sparse_residual, sparse_scale, status)
+        call write_value(iunit, tag, 'solved_constant', solve_index, &
+            solve_residual, solve_scale, status)
         close(iunit, iostat=ierr)
         if (status /= 0 .or. ierr /= 0) ierr = 3
     end subroutine record_local_constant_stage_residuals

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -280,8 +280,10 @@ contains
 
     subroutine record_local_constant_stage_residuals(tag, sparse_residual, &
             sparse_scale, sparse_index, solve_residual, solve_scale, &
-            solve_index, ierr)
-        integer, intent(in) :: tag, sparse_index, solve_index
+            solve_index, sparse_step, sparse_laguerre, sparse_sigma, &
+            sparse_band, ierr)
+        integer, intent(in) :: tag, sparse_index, solve_index, sparse_step
+        integer, intent(in) :: sparse_laguerre, sparse_sigma, sparse_band
         real(real64), intent(in) :: sparse_residual, sparse_scale
         real(real64), intent(in) :: solve_residual, solve_scale
         integer, intent(out) :: ierr
@@ -299,6 +301,14 @@ contains
             sparse_residual, sparse_scale, status)
         call write_value(iunit, tag, 'solved_constant', solve_index, &
             solve_residual, solve_scale, status)
+        call write_value(iunit, tag, 'sparse_step', sparse_step, &
+            sparse_residual, sparse_scale, status)
+        call write_value(iunit, tag, 'sparse_laguerre', sparse_laguerre, &
+            sparse_residual, sparse_scale, status)
+        call write_value(iunit, tag, 'sparse_sigma', sparse_sigma, &
+            sparse_residual, sparse_scale, status)
+        call write_value(iunit, tag, 'sparse_band', sparse_band, &
+            sparse_residual, sparse_scale, status)
         close(iunit, iostat=ierr)
         if (status /= 0 .or. ierr /= 0) ierr = 3
     end subroutine record_local_constant_stage_residuals

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -377,7 +377,8 @@ contains
         ierr = 1
         if (index < 1 .or. lag < 0 .or. ibeg > iend) return
         step = ibeg
-        do while (step < iend .and. index > ind_start(step + 1))
+        do while (step < iend)
+            if (index <= ind_start(step + 1)) exit
             step = step + 1
         end do
         nbands = npl(step) + 1

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -21,6 +21,7 @@ module lorentz_projection_diagnostics_mod
     character(len=:), allocatable, save :: output_filename
     integer, save :: record_sequence = 0
     logical, save :: output_initialized = .false.
+    logical, save :: row_output_initialized = .false.
 
     public :: compute_local_projection_residuals
     public :: assemble_local_constant_state
@@ -28,6 +29,7 @@ module lorentz_projection_diagnostics_mod
     public :: local_projection_trace_enabled
     public :: record_local_projection_residuals
     public :: record_local_constant_stage_residuals
+    public :: record_local_constant_row
 
 contains
 
@@ -312,6 +314,44 @@ contains
         close(iunit, iostat=ierr)
         if (status /= 0 .or. ierr /= 0) ierr = 3
     end subroutine record_local_constant_stage_residuals
+
+    subroutine record_local_constant_row(tag, row, irow, icol, values, state, &
+            rhs, ierr)
+        integer, intent(in) :: tag, row, irow(:), icol(:)
+        real(real64), intent(in) :: values(:), state(:), rhs(:)
+        integer, intent(out) :: ierr
+        character(len=:), allocatable :: filename
+        integer :: entry, iunit, status
+
+        ierr = 1
+        if (.not. allocated(output_filename)) return
+        if (size(irow) /= size(icol) .or. size(irow) /= size(values)) return
+        if (row < 1 .or. row > size(state) .or. size(rhs) /= size(state)) return
+        filename = output_filename//'.rows'
+        status = 0
+        if (.not. row_output_initialized) then
+            open(newunit=iunit, file=filename, status='replace', action='write', &
+                iostat=status)
+            if (status == 0) write(iunit, '(a)', iostat=status) &
+                'propagator,row,column,coefficient,state,contribution,rhs'
+            if (status == 0) close(iunit, iostat=status)
+            if (status /= 0) return
+            row_output_initialized = .true.
+        end if
+        open(newunit=iunit, file=filename, status='old', position='append', &
+            action='write', iostat=status)
+        if (status /= 0) return
+        do entry = 1, size(values)
+            if (irow(entry) /= row) cycle
+            write(iunit, '(i0,",",i0,",",i0,4(",",es25.16e3))', &
+                iostat=status) &
+                tag, row, icol(entry), values(entry), state(icol(entry)), &
+                values(entry)*state(icol(entry)), rhs(row)
+            if (status /= 0) exit
+        end do
+        close(iunit, iostat=ierr)
+        if (status /= 0 .or. ierr /= 0) ierr = 3
+    end subroutine record_local_constant_row
 
     subroutine write_value(iunit, tag, kind, index, value, scale, status)
         integer, intent(in) :: iunit, tag, index

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -23,9 +23,89 @@ module lorentz_projection_diagnostics_mod
     logical, save :: output_initialized = .false.
 
     public :: compute_local_projection_residuals
+    public :: assemble_local_constant_state
+    public :: compute_sparse_constant_residual
+    public :: local_projection_trace_enabled
     public :: record_local_projection_residuals
+    public :: record_local_constant_stage_residuals
 
 contains
+
+    subroutine local_projection_trace_enabled(enabled, ierr)
+        logical, intent(out) :: enabled
+        integer, intent(out) :: ierr
+
+        call initialize_output(ierr)
+        enabled = ierr == 0 .and. allocated(output_filename)
+    end subroutine local_projection_trace_enabled
+
+    subroutine assemble_local_constant_state(state, rhs, npl, ind_start, eta, &
+            bhat, ibeg, iend, lag, ierr)
+        real(real64), intent(out) :: state(:), rhs(:)
+        integer, intent(in) :: npl(ibeg:), ind_start(ibeg:)
+        real(real64), intent(in) :: eta(0:), bhat(ibeg:)
+        integer, intent(in) :: ibeg, iend, lag
+        integer, intent(out) :: ierr
+        real(real64), allocatable :: widths(:)
+        integer :: base, expected_size, istep, npass, nbands
+
+        ierr = 1
+        if (ibeg > iend .or. lag < 0) return
+        expected_size = ind_start(iend) + 2*(lag + 1)*(npl(iend) + 1)
+        if (size(state) /= expected_size .or. size(rhs) /= expected_size) return
+        if (size(eta) <= maxval(npl(ibeg:iend))) return
+        if (any(bhat(ibeg:iend) <= 0.0_real64)) return
+        allocate(widths(maxval(npl(ibeg:iend)) + 1))
+        state = 0.0_real64
+        rhs = 0.0_real64
+        do istep = ibeg, iend
+            npass = npl(istep)
+            nbands = npass + 1
+            base = ind_start(istep)
+            if (npass > 0) &
+                widths(1:npass) = eta(1:npass) - eta(0:npass - 1)
+            widths(nbands) = 1.0_real64/bhat(istep) - eta(npass)
+            if (any(widths(1:nbands) <= 0.0_real64)) return
+            state(base + 1:base + nbands) = widths(1:nbands)
+            state(base + nbands + 1:base + 2*nbands) = widths(nbands:1:-1)
+        end do
+        nbands = npl(ibeg) + 1
+        rhs(ind_start(ibeg) + 1:ind_start(ibeg) + nbands) = &
+            state(ind_start(ibeg) + 1:ind_start(ibeg) + nbands)
+        nbands = npl(iend) + 1
+        base = ind_start(iend)
+        rhs(base + nbands + 1:base + 2*nbands) = &
+            state(base + nbands + 1:base + 2*nbands)
+        ierr = 0
+    end subroutine assemble_local_constant_state
+
+    subroutine compute_sparse_constant_residual(irow, icol, values, state, rhs, &
+            residual, scale, ierr)
+        integer, intent(in) :: irow(:), icol(:)
+        real(real64), intent(in) :: values(:), state(:), rhs(:)
+        real(real64), intent(out) :: residual, scale
+        integer, intent(out) :: ierr
+        real(real64), allocatable :: row_residual(:), row_scale(:)
+        integer :: entry
+
+        ierr = 1
+        if (size(irow) /= size(icol) .or. size(irow) /= size(values)) return
+        if (size(state) /= size(rhs)) return
+        if (any(irow < 1) .or. any(irow > size(state))) return
+        if (any(icol < 1) .or. any(icol > size(state))) return
+        allocate(row_residual(size(state)), row_scale(size(state)))
+        row_residual = -rhs
+        row_scale = abs(rhs)
+        do entry = 1, size(values)
+            row_residual(irow(entry)) = row_residual(irow(entry)) + &
+                values(entry)*state(icol(entry))
+            row_scale(irow(entry)) = row_scale(irow(entry)) + &
+                abs(values(entry))*abs(state(icol(entry)))
+        end do
+        residual = maxval(abs(row_residual))
+        scale = max(maxval(row_scale), tiny(1.0_real64))
+        ierr = 0
+    end subroutine compute_sparse_constant_residual
 
     subroutine compute_local_projection_residuals(source_p, source_m, flux_p, &
             flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
@@ -195,6 +275,30 @@ contains
         close(iunit, iostat=ierr)
         if (status /= 0 .or. ierr /= 0) ierr = 3
     end subroutine record_local_projection_residuals
+
+    subroutine record_local_constant_stage_residuals(tag, sparse_residual, &
+            sparse_scale, solve_residual, solve_scale, ierr)
+        integer, intent(in) :: tag
+        real(real64), intent(in) :: sparse_residual, sparse_scale
+        real(real64), intent(in) :: solve_residual, solve_scale
+        integer, intent(out) :: ierr
+        integer :: iunit, status
+
+        call initialize_output(ierr)
+        if (ierr /= 0 .or. .not. allocated(output_filename)) return
+        open(newunit=iunit, file=output_filename, status='old', position='append', &
+            action='write', iostat=status)
+        if (status /= 0) then
+            ierr = 3
+            return
+        end if
+        call write_value(iunit, tag, 'sparse_constant', -1, sparse_residual, &
+            sparse_scale, status)
+        call write_value(iunit, tag, 'solved_constant', -1, solve_residual, &
+            solve_scale, status)
+        close(iunit, iostat=ierr)
+        if (status /= 0 .or. ierr /= 0) ierr = 3
+    end subroutine record_local_constant_stage_residuals
 
     subroutine write_value(iunit, tag, kind, index, value, scale, status)
         integer, intent(in) :: iunit, tag, index

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -99,7 +99,8 @@ SUBROUTINE ripple_solver(                                 &
        qflux_point_components_from_flux_vector, record_qflux_interface_traces
   USE lorentz_projection_diagnostics_mod, ONLY : &
        assemble_local_constant_state, compute_sparse_constant_residual, &
-       local_projection_trace_enabled, record_local_constant_stage_residuals
+       local_projection_trace_enabled, record_local_constant_row, &
+       record_local_constant_stage_residuals
   !! End Modification by Andreas F. Martitsch (28.07.2015)
 
   IMPLICIT NONE
@@ -2556,6 +2557,13 @@ PRINT *,'right boundary layer ignored'
     CALL compute_sparse_constant_residual(irow(1:nz),icol(1:nz), &
       amat_sp(1:nz),constant_state,constant_rhs,constant_sparse_residual, &
       constant_sparse_scale,constant_sparse_index,constant_trace_ierr)
+    IF(constant_trace_ierr.NE.0) THEN
+      ierr=constant_trace_ierr
+      RETURN
+    ENDIF
+    CALL record_local_constant_row(fieldpropagator%tag,constant_sparse_index, &
+      irow(1:nz),icol(1:nz),amat_sp(1:nz),constant_state,constant_rhs, &
+      constant_trace_ierr)
     IF(constant_trace_ierr.NE.0) THEN
       ierr=constant_trace_ierr
       RETURN

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -239,7 +239,7 @@ SUBROUTINE ripple_solver(                                 &
   LOGICAL :: hel_drive_active,trace_constant_state
   DOUBLE PRECISION :: constant_sparse_residual,constant_sparse_scale
   DOUBLE PRECISION :: constant_solve_residual,constant_solve_scale
-  INTEGER :: constant_trace_ierr
+  INTEGER :: constant_sparse_index,constant_solve_index,constant_trace_ierr
   INTEGER :: n_hel
   INTEGER :: isw_lor,isw_ene,isw_intp
   INTEGER,          DIMENSION(:),       ALLOCATABLE :: npl
@@ -2553,7 +2553,7 @@ PRINT *,'right boundary layer ignored'
     ENDIF
     CALL compute_sparse_constant_residual(irow(1:nz),icol(1:nz), &
       amat_sp(1:nz),constant_state,constant_rhs,constant_sparse_residual, &
-      constant_sparse_scale,constant_trace_ierr)
+      constant_sparse_scale,constant_sparse_index,constant_trace_ierr)
     IF(constant_trace_ierr.NE.0) THEN
       ierr=constant_trace_ierr
       RETURN
@@ -2586,12 +2586,15 @@ PRINT *,'right boundary layer ignored'
     bvec_sp=constant_rhs
     CALL sparse_solve(nrow,ncol,nz,irow(1:nz),ipcol,amat_sp(1:nz), &
       bvec_sp,iopt)
-    constant_solve_residual=MAXVAL(ABS(bvec_sp-constant_state))
-    constant_solve_scale=MAX(MAXVAL(ABS(bvec_sp)+ABS(constant_state)), &
-      TINY(1.d0))
+    constant_solve_index=MAXLOC(ABS(bvec_sp-constant_state),DIM=1)
+    constant_solve_residual=bvec_sp(constant_solve_index) &
+      -constant_state(constant_solve_index)
+    constant_solve_scale=MAX(ABS(bvec_sp(constant_solve_index)) &
+      +ABS(constant_state(constant_solve_index)),TINY(1.d0))
     CALL record_local_constant_stage_residuals(fieldpropagator%tag, &
-      constant_sparse_residual,constant_sparse_scale,constant_solve_residual, &
-      constant_solve_scale,constant_trace_ierr)
+      constant_sparse_residual,constant_sparse_scale,constant_sparse_index, &
+      constant_solve_residual,constant_solve_scale,constant_solve_index, &
+      constant_trace_ierr)
     IF(constant_trace_ierr.NE.0) THEN
       ierr=constant_trace_ierr
       RETURN

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -240,6 +240,8 @@ SUBROUTINE ripple_solver(                                 &
   DOUBLE PRECISION :: constant_sparse_residual,constant_sparse_scale
   DOUBLE PRECISION :: constant_solve_residual,constant_solve_scale
   INTEGER :: constant_sparse_index,constant_solve_index,constant_trace_ierr
+  INTEGER :: constant_sparse_step,constant_sparse_laguerre
+  INTEGER :: constant_sparse_sigma,constant_sparse_band,constant_local_index
   INTEGER :: n_hel
   INTEGER :: isw_lor,isw_ene,isw_intp
   INTEGER,          DIMENSION(:),       ALLOCATABLE :: npl
@@ -2558,6 +2560,25 @@ PRINT *,'right boundary layer ignored'
       ierr=constant_trace_ierr
       RETURN
     ENDIF
+    constant_sparse_step=ibeg
+    DO WHILE(constant_sparse_index.GT.ind_start(constant_sparse_step) &
+      +2*(lag+1)*(npl(constant_sparse_step)+1))
+      constant_sparse_step=constant_sparse_step+1
+    ENDDO
+    constant_local_index=constant_sparse_index &
+      -ind_start(constant_sparse_step)-1
+    constant_sparse_laguerre=constant_local_index &
+      /(2*(npl(constant_sparse_step)+1))
+    constant_local_index=MOD(constant_local_index, &
+      2*(npl(constant_sparse_step)+1))+1
+    IF(constant_local_index.LE.npl(constant_sparse_step)+1) THEN
+      constant_sparse_sigma=1
+      constant_sparse_band=constant_local_index
+    ELSE
+      constant_sparse_sigma=-1
+      constant_sparse_band=2*(npl(constant_sparse_step)+1) &
+        -constant_local_index+1
+    ENDIF
   ENDIF
 
   CALL column_full2pointer(icol(1:nz),ipcol)
@@ -2594,6 +2615,8 @@ PRINT *,'right boundary layer ignored'
     CALL record_local_constant_stage_residuals(fieldpropagator%tag, &
       constant_sparse_residual,constant_sparse_scale,constant_sparse_index, &
       constant_solve_residual,constant_solve_scale,constant_solve_index, &
+      constant_sparse_step,constant_sparse_laguerre,constant_sparse_sigma, &
+      constant_sparse_band, &
       constant_trace_ierr)
     IF(constant_trace_ierr.NE.0) THEN
       ierr=constant_trace_ierr

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -2563,7 +2563,7 @@ PRINT *,'right boundary layer ignored'
     ENDIF
     CALL record_local_constant_row(fieldpropagator%tag,constant_sparse_index, &
       irow(1:nz),icol(1:nz),amat_sp(1:nz),constant_state,constant_rhs, &
-      constant_trace_ierr)
+      npl,ind_start,bhat_mfl,ibeg,iend,lag,constant_trace_ierr)
     IF(constant_trace_ierr.NE.0) THEN
       ierr=constant_trace_ierr
       RETURN
@@ -2573,19 +2573,18 @@ PRINT *,'right boundary layer ignored'
       +2*(lag+1)*(npl(constant_sparse_step)+1))
       constant_sparse_step=constant_sparse_step+1
     ENDDO
-    constant_local_index=constant_sparse_index &
-      -ind_start(constant_sparse_step)-1
+    constant_local_index=constant_sparse_index-ind_start(constant_sparse_step)-1
     constant_sparse_laguerre=constant_local_index &
       /(2*(npl(constant_sparse_step)+1))
     constant_local_index=MOD(constant_local_index, &
-      2*(npl(constant_sparse_step)+1))+1
-    IF(constant_local_index.LE.npl(constant_sparse_step)+1) THEN
+      2*(npl(constant_sparse_step)+1))
+    IF(constant_local_index.LT.npl(constant_sparse_step)+1) THEN
       constant_sparse_sigma=1
-      constant_sparse_band=constant_local_index
+      constant_sparse_band=constant_local_index+1
     ELSE
       constant_sparse_sigma=-1
       constant_sparse_band=2*(npl(constant_sparse_step)+1) &
-        -constant_local_index+1
+        -constant_local_index
     ENDIF
   ENDIF
 

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -97,6 +97,9 @@ SUBROUTINE ripple_solver(                                 &
   USE partpa_mod, ONLY : bmod0
   USE qflux_profile_mod, ONLY : qflux_contributions_from_flux_vector, &
        qflux_point_components_from_flux_vector, record_qflux_interface_traces
+  USE lorentz_projection_diagnostics_mod, ONLY : &
+       assemble_local_constant_state, compute_sparse_constant_residual, &
+       local_projection_trace_enabled, record_local_constant_stage_residuals
   !! End Modification by Andreas F. Martitsch (28.07.2015)
 
   IMPLICIT NONE
@@ -228,11 +231,15 @@ SUBROUTINE ripple_solver(                                 &
   DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: amat_sp,funsol_p,funsol_m
   DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: bvec_sp,bvec_iter,bvec_lor
   DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: bvec_prev
+  DOUBLE PRECISION, DIMENSION(:),   ALLOCATABLE :: constant_state,constant_rhs
   DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: flux_vector,source_vector
   COMPLEX(kind=dp), DIMENSION(:,:), ALLOCATABLE :: helical_source
   COMPLEX(kind=dp), DIMENSION(:,:), ALLOCATABLE :: q_hel_b,q_hel_e
   COMPLEX(kind=dp) :: amp_hel_b,amp_hel_e,hel_phase,hel_phase_fac
-  LOGICAL :: hel_drive_active
+  LOGICAL :: hel_drive_active,trace_constant_state
+  DOUBLE PRECISION :: constant_sparse_residual,constant_sparse_scale
+  DOUBLE PRECISION :: constant_solve_residual,constant_solve_scale
+  INTEGER :: constant_trace_ierr
   INTEGER :: n_hel
   INTEGER :: isw_lor,isw_ene,isw_intp
   INTEGER,          DIMENSION(:),       ALLOCATABLE :: npl
@@ -2528,6 +2535,31 @@ PRINT *,'right boundary layer ignored'
   print *,'non-zeros before and after truncation = ',nz,nz_sq
   nz=nz_sq
 
+  trace_constant_state=.FALSE.
+  IF(isw_lorentz.EQ.1) THEN
+    CALL local_projection_trace_enabled(trace_constant_state,constant_trace_ierr)
+    IF(constant_trace_ierr.NE.0) THEN
+      ierr=constant_trace_ierr
+      RETURN
+    ENDIF
+  ENDIF
+  IF(trace_constant_state) THEN
+    ALLOCATE(constant_state(n_2d_size),constant_rhs(n_2d_size))
+    CALL assemble_local_constant_state(constant_state,constant_rhs,npl, &
+      ind_start,eta,bhat_mfl,ibeg,iend,lag,constant_trace_ierr)
+    IF(constant_trace_ierr.NE.0) THEN
+      ierr=constant_trace_ierr
+      RETURN
+    ENDIF
+    CALL compute_sparse_constant_residual(irow(1:nz),icol(1:nz), &
+      amat_sp(1:nz),constant_state,constant_rhs,constant_sparse_residual, &
+      constant_sparse_scale,constant_trace_ierr)
+    IF(constant_trace_ierr.NE.0) THEN
+      ierr=constant_trace_ierr
+      RETURN
+    ENDIF
+  ENDIF
+
   CALL column_full2pointer(icol(1:nz),ipcol)
 
 ! There are now three different calls sparse_solve
@@ -2549,6 +2581,23 @@ PRINT *,'right boundary layer ignored'
   print *,'factorization completed ',time_factorization - time_start,' sec'
 
   iopt=2
+
+  IF(trace_constant_state) THEN
+    bvec_sp=constant_rhs
+    CALL sparse_solve(nrow,ncol,nz,irow(1:nz),ipcol,amat_sp(1:nz), &
+      bvec_sp,iopt)
+    constant_solve_residual=MAXVAL(ABS(bvec_sp-constant_state))
+    constant_solve_scale=MAX(MAXVAL(ABS(bvec_sp)+ABS(constant_state)), &
+      TINY(1.d0))
+    CALL record_local_constant_stage_residuals(fieldpropagator%tag, &
+      constant_sparse_residual,constant_sparse_scale,constant_solve_residual, &
+      constant_solve_scale,constant_trace_ierr)
+    IF(constant_trace_ierr.NE.0) THEN
+      ierr=constant_trace_ierr
+      RETURN
+    ENDIF
+    DEALLOCATE(constant_state,constant_rhs)
+  ENDIF
 
 ! Solution of inhomogeneus equation (account of sources):
 

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -3,7 +3,8 @@ program test_lorentz_projection_diagnostic
     use lorentz_projection_diagnostics_mod, only: &
         assemble_local_constant_state, compute_local_projection_residuals, &
         compute_sparse_constant_residual, local_projection_residuals, &
-        record_local_constant_stage_residuals, record_local_projection_residuals
+        record_local_constant_row, record_local_constant_stage_residuals, &
+        record_local_projection_residuals
     implicit none
 
     real(real64) :: source_p(1, 3), source_m(1, 3)
@@ -16,7 +17,7 @@ program test_lorentz_projection_diagnostic
     real(real64) :: eta(0:1), bhat(1:2)
     integer :: npl(1:2), ind_start(1:2), matrix_index(8), residual_index
     type(local_projection_residuals) :: residuals
-    character(len=1024) :: filename, line
+    character(len=1024) :: filename, line, row_filename
     integer :: ierr, iunit, line_count, status
 
     source_p = reshape([1.0_real64, 2.0_real64, 3.0_real64], [1, 3])
@@ -77,6 +78,9 @@ program test_lorentz_projection_diagnostic
     call record_local_constant_stage_residuals(7, residual, scale, &
         residual_index, residual, scale, residual_index, 2, 0, -1, 1, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
+    call record_local_constant_row(7, 1, matrix_index, matrix_index, &
+        matrix_values, constant_state, constant_state, ierr)
+    if (ierr /= 0) error stop 'FAIL: constant-row trace was not written'
     call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
         value=filename, status=status)
     if (status /= 0) error stop 'FAIL: projection trace path is absent'
@@ -89,6 +93,16 @@ program test_lorentz_projection_diagnostic
     end do
     close (iunit)
     if (line_count /= 17) error stop 'FAIL: projection trace row count differs'
+    row_filename = trim(filename)//'.rows'
+    open (newunit=iunit, file=trim(row_filename), status='old', action='read')
+    line_count = 0
+    do
+        read (iunit, '(a)', iostat=status) line
+        if (status /= 0) exit
+        line_count = line_count + 1
+    end do
+    close (iunit)
+    if (line_count /= 2) error stop 'FAIL: constant-row trace row count differs'
 
     call compute_local_projection_residuals(source_p, source_m, flux_p, flux_m, &
         amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, -0.4_real64, &

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -78,7 +78,7 @@ program test_lorentz_projection_diagnostic
     call record_local_constant_stage_residuals(7, residual, scale, &
         residual_index, residual, scale, residual_index, 2, 0, -1, 1, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
-    call record_local_constant_row(7, 1, matrix_index, matrix_index, &
+    call record_local_constant_row(7, 8, matrix_index, matrix_index, &
         matrix_values, constant_state, constant_state, npl, ind_start, bhat, &
         1, 2, 0, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-row trace was not written'

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -75,7 +75,7 @@ program test_lorentz_projection_diagnostic
         0.4_real64, 0.6_real64, ierr)
     if (ierr /= 0) error stop 'FAIL: projection trace was not written'
     call record_local_constant_stage_residuals(7, residual, scale, &
-        residual_index, residual, scale, residual_index, ierr)
+        residual_index, residual, scale, residual_index, 2, 0, -1, 1, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
     call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
         value=filename, status=status)
@@ -88,7 +88,7 @@ program test_lorentz_projection_diagnostic
         line_count = line_count + 1
     end do
     close (iunit)
-    if (line_count /= 13) error stop 'FAIL: projection trace row count differs'
+    if (line_count /= 17) error stop 'FAIL: projection trace row count differs'
 
     call compute_local_projection_residuals(source_p, source_m, flux_p, flux_m, &
         amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, -0.4_real64, &

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -1,8 +1,9 @@
 program test_lorentz_projection_diagnostic
     use, intrinsic :: iso_fortran_env, only: real64
     use lorentz_projection_diagnostics_mod, only: &
-        compute_local_projection_residuals, local_projection_residuals, &
-        record_local_projection_residuals
+        assemble_local_constant_state, compute_local_projection_residuals, &
+        compute_sparse_constant_residual, local_projection_residuals, &
+        record_local_constant_stage_residuals, record_local_projection_residuals
     implicit none
 
     real(real64) :: source_p(1, 3), source_m(1, 3)
@@ -10,6 +11,10 @@ program test_lorentz_projection_diagnostic
     real(real64) :: amat_p_p(1, 1), amat_m_p(1, 1)
     real(real64) :: amat_p_m(1, 1), amat_m_m(1, 1)
     real(real64) :: eta_l(0:0), eta_r(0:0)
+    real(real64) :: constant_state(8), constant_rhs(8), matrix_values(8)
+    real(real64) :: residual, scale
+    real(real64) :: eta(0:1), bhat(1:2)
+    integer :: npl(1:2), ind_start(1:2), matrix_index(8)
     type(local_projection_residuals) :: residuals
     character(len=1024) :: filename, line
     integer :: ierr, iunit, line_count, status
@@ -44,10 +49,33 @@ program test_lorentz_projection_diagnostic
     if (residuals%intertwining /= 0.0_real64) &
         error stop 'FAIL: projector intertwining was not recognized'
 
+    npl = [1, 1]
+    ind_start = [0, 4]
+    eta = [0.0_real64, 0.2_real64]
+    bhat = [2.0_real64, 2.5_real64]
+    call assemble_local_constant_state(constant_state, constant_rhs, npl, &
+        ind_start, eta, bhat, 1, 2, 0, ierr)
+    if (ierr /= 0) error stop 'FAIL: valid constant state input rejected'
+    if (maxval(abs(constant_state - [0.2_real64, 0.3_real64, 0.3_real64, &
+        0.2_real64, 0.2_real64, 0.2_real64, 0.2_real64, 0.2_real64])) &
+        > 1.0e-15_real64) error stop 'FAIL: constant state is incorrect'
+    if (maxval(abs(constant_rhs - [0.2_real64, 0.3_real64, 0.0_real64, &
+        0.0_real64, 0.0_real64, 0.0_real64, 0.2_real64, 0.2_real64])) &
+        > 1.0e-15_real64) error stop 'FAIL: constant boundary rhs is incorrect'
+    matrix_index = [(status, status=1, 8)]
+    matrix_values = 1.0_real64
+    call compute_sparse_constant_residual(matrix_index, matrix_index, &
+        matrix_values, constant_state, constant_state, residual, scale, ierr)
+    if (ierr /= 0 .or. residual /= 0.0_real64) &
+        error stop 'FAIL: exact sparse constant state was not recognized'
+
     call record_local_projection_residuals(7, source_p, source_m, flux_p, &
         flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
         0.4_real64, 0.6_real64, ierr)
     if (ierr /= 0) error stop 'FAIL: projection trace was not written'
+    call record_local_constant_stage_residuals(7, residual, scale, residual, &
+        scale, ierr)
+    if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
     call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
         value=filename, status=status)
     if (status /= 0) error stop 'FAIL: projection trace path is absent'
@@ -59,7 +87,7 @@ program test_lorentz_projection_diagnostic
         line_count = line_count + 1
     end do
     close (iunit)
-    if (line_count /= 11) error stop 'FAIL: projection trace row count differs'
+    if (line_count /= 13) error stop 'FAIL: projection trace row count differs'
 
     call compute_local_projection_residuals(source_p, source_m, flux_p, flux_m, &
         amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, -0.4_real64, &

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -79,7 +79,8 @@ program test_lorentz_projection_diagnostic
         residual_index, residual, scale, residual_index, 2, 0, -1, 1, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
     call record_local_constant_row(7, 1, matrix_index, matrix_index, &
-        matrix_values, constant_state, constant_state, ierr)
+        matrix_values, constant_state, constant_state, npl, ind_start, bhat, &
+        1, 2, 0, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-row trace was not written'
     call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
         value=filename, status=status)

--- a/TEST/test_lorentz_projection_diagnostic.f90
+++ b/TEST/test_lorentz_projection_diagnostic.f90
@@ -14,7 +14,7 @@ program test_lorentz_projection_diagnostic
     real(real64) :: constant_state(8), constant_rhs(8), matrix_values(8)
     real(real64) :: residual, scale
     real(real64) :: eta(0:1), bhat(1:2)
-    integer :: npl(1:2), ind_start(1:2), matrix_index(8)
+    integer :: npl(1:2), ind_start(1:2), matrix_index(8), residual_index
     type(local_projection_residuals) :: residuals
     character(len=1024) :: filename, line
     integer :: ierr, iunit, line_count, status
@@ -65,7 +65,8 @@ program test_lorentz_projection_diagnostic
     matrix_index = [(status, status=1, 8)]
     matrix_values = 1.0_real64
     call compute_sparse_constant_residual(matrix_index, matrix_index, &
-        matrix_values, constant_state, constant_state, residual, scale, ierr)
+        matrix_values, constant_state, constant_state, residual, scale, &
+        residual_index, ierr)
     if (ierr /= 0 .or. residual /= 0.0_real64) &
         error stop 'FAIL: exact sparse constant state was not recognized'
 
@@ -73,8 +74,8 @@ program test_lorentz_projection_diagnostic
         flux_m, amat_p_p, amat_m_p, amat_p_m, amat_m_m, eta_l, eta_r, &
         0.4_real64, 0.6_real64, ierr)
     if (ierr /= 0) error stop 'FAIL: projection trace was not written'
-    call record_local_constant_stage_residuals(7, residual, scale, residual, &
-        scale, ierr)
+    call record_local_constant_stage_residuals(7, residual, scale, &
+        residual_index, residual, scale, residual_index, ierr)
     if (ierr /= 0) error stop 'FAIL: constant-stage trace was not written'
     call get_environment_variable('NEO2_LOCAL_PROJECTION_TRACE_FILE', &
         value=filename, status=status)


### PR DESCRIPTION
## Summary

Add an opt-in stage trace that evaluates the exact pitch-independent Lorentz state at three points in every single-ripple propagator:

1. against the assembled sparse equations before factorization;
2. after one direct sparse solve with exact constant boundary data;
3. in the extracted boundary map already traced by #162.

This PR is stacked on #162. It is the minimum measurement needed to localize the finite-resolution constant-distribution transport defect before changing the solver.

The internal state uses the code's documented unknown

\[
Y_k=\int_{\eta_{k-1}}^{\eta_k}f\,d\eta,
\]

including the moving final-band width \(1/B-\eta_N\) and the reversed storage order of the counter-passing branch. The sparse right-hand side applies those exact widths only at the incoming co-passing and counter-passing boundaries. The matrix residual and solved-state error are appended to `NEO2_LOCAL_PROJECTION_TRACE_FILE`; with that variable unset, the new path returns before allocation and does not call the extra solve.

## Decision rule

- Nonzero sparse residual: discretization or mirror matching is inconsistent with constant \(f\).
- Sparse residual closes but solved state does not: sparse factorization or solve is responsible.
- Solved state closes but #162's boundary map does not: propagator extraction is responsible.

No correction is applied in this PR. The measured stage will determine the smallest justified fix.

## Preserved invariants

- Lorentz collision and physical source terms are unchanged.
- Pitch and spatial discretizations, solver tolerances, and convergence criteria are unchanged.
- Fourier convention, CGS units, periodic streaming, and mirror boundary conditions are unchanged.
- ABI, serialized propagator layout, and generated physics outputs are unchanged.

## Verification

### Test fails on main

Main has no executable check for the exact internal constant state or its sparse residual:

```text
Test project .../build
No tests were found!!!
Errors while running CTest
```

### Test passes after fix

```text
$ fo test lorentz_projection_diagnostic_test
lorentz_projection_diagnostic_test PASS 0.06s
Summary: 1 passed, 0 failed, 0 skipped

$ fo
Static: OK
Build: OK
Tests: OK
Lint: OK
Fmt: WARN (legacy ripple_solver_axi_test.f90)
All stages passed
```

## Diagnosis and successor

The stage trace localized the defect to a topology crossing, not the sparse
factorization, boundary-map extraction, pitch transfer, joining, or the Lorentz
collision stencil. In propagator 192, the number of passing bands falls from 27
to 26 between spatial steps 679 and 680. The old placement routine does not
align the crossing sample when that sample is closer than both neighbours. The
constant-distribution widths on the two sides then differ by
`3.365342566301611e-4`; multiplication by the streaming coefficient produces
the complete `5.1395606791432513e-2` sparse row residual. Collision terms cancel
on the same row.

PR #164 supplies the stacked correction and regression. At its pinned head,
the worst normalized sparse constant residual is `1.0147e-16`, the worst solved
constant-state error is `3.0437e-14`, and the full 199-propagator reconstruction
completes with the same eight adaptive retries as the stacked base. A retained
stage-0 trace closes right transport at `2.2289e-14` and projector intertwining
at `2.3275e-14`. The failure-free campaign remains open. This PR remains
diagnostic-only.
