### PR TITLE
Align pitch crossings to the nearest grid point

### DIFF
--- a/NEO-2-QL/CMakeSources.in
+++ b/NEO-2-QL/CMakeSources.in
@@ -5,6 +5,7 @@ set(NEO2_QL_SRC_FILES
   helical_source_mod.f90
   helical_response_mod.f90
   qflux_profile_mod.f90
+  phi_crossing_alignment_mod.f90
   propagator.f90
   flint.f90
   ripple_solver_axi_test.f90

--- a/NEO-2-QL/phi_crossing_alignment_mod.f90
+++ b/NEO-2-QL/phi_crossing_alignment_mod.f90
@@ -1,0 +1,21 @@
+module phi_crossing_alignment_mod
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+
+contains
+
+    pure integer function nearest_phi_crossing_offset(bhat, eta_cross) &
+            result(offset)
+        real(dp), intent(in) :: bhat(-1:1)
+        real(dp), intent(in) :: eta_cross
+
+        real(dp) :: residual(-1:1)
+
+        residual = abs(bhat*eta_cross - 1.0_dp)
+        offset = 0
+        if (residual(-1) < residual(offset)) offset = -1
+        if (residual(1) < residual(offset)) offset = 1
+    end function nearest_phi_crossing_offset
+
+end module phi_crossing_alignment_mod

--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -5270,13 +5270,14 @@ subroutine fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
                                     phi_mfl, bhat_mfl, eta)
 
     use device_mod
+    use phi_crossing_alignment_mod, only: nearest_phi_crossing_offset
 
     implicit none
 
     integer, parameter :: dp = kind(1.0d0)
 
     integer :: i, ibeg, iend, npart, istep, ibmin, npassing, npassing_prev
-    integer :: ncross_l, ncross_r
+    integer :: aligned_step, crossing_offset, ncross_l, ncross_r
 
     real(dp) :: subsqmin
 
@@ -5286,6 +5287,7 @@ subroutine fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
     real(dp), dimension(0:npart)        :: eta
     real(dp), dimension(ibeg:iend)      :: phi_mfl, bhat_mfl
     real(dp), dimension(:), allocatable :: eta_cross_l, eta_cross_r
+    real(dp) :: bhat_crossing(-1:1)
 
     npassing = -1
 
@@ -5347,25 +5349,19 @@ subroutine fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
             end do
             do i = 1, ncross_l
                 istep = icross_l(i)
-                if (ABS(bhat_mfl(istep - 1)*eta_cross_l(i) - 1.d0) .LT. &
-                    ABS(bhat_mfl(istep)*eta_cross_l(i) - 1.d0)) then
-                    open (111, file='phi_placement_problem.dat', position='append')
-                    write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                        ' step number = ', istep - 1, &
-                        ' 1 / bhat = ', 1.d0/bhat_mfl(istep - 1), &
-                        ' eta = ', eta_cross_l(i)
-                    close (111)
-                    bhat_mfl(istep - 1) = 1/eta_cross_l(i)
-                elseif (ABS(bhat_mfl(istep + 1)*eta_cross_l(i) - 1.d0) .LT. &
-                        ABS(bhat_mfl(istep)*eta_cross_l(i) - 1.d0)) then
-                    open (111, file='phi_placement_problem.dat', position='append')
-                    write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                        ' step number = ', istep + 1, &
-                        ' 1 / bhat = ', 1.d0/bhat_mfl(istep + 1), &
-                        ' eta = ', eta_cross_l(i)
-                    bhat_mfl(istep + 1) = 1/eta_cross_l(i)
-                    close (111)
-                end if
+                bhat_crossing = bhat_mfl(istep)
+                if (istep .GT. ibeg) bhat_crossing(-1) = bhat_mfl(istep - 1)
+                if (istep .LT. iend) bhat_crossing(1) = bhat_mfl(istep + 1)
+                crossing_offset = nearest_phi_crossing_offset( &
+                    bhat_crossing, eta_cross_l(i))
+                aligned_step = istep + crossing_offset
+                open (111, file='phi_placement_problem.dat', position='append')
+                write (111, *) ' propagator tag = ', fieldpropagator%tag, &
+                    ' step number = ', aligned_step, &
+                    ' 1 / bhat = ', 1.d0/bhat_mfl(aligned_step), &
+                    ' eta = ', eta_cross_l(i)
+                close (111)
+                bhat_mfl(aligned_step) = 1.d0/eta_cross_l(i)
             end do
             deallocate (icross_l, eta_cross_l)
         end if
@@ -5424,25 +5420,19 @@ subroutine fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
             end do
             do i = 1, ncross_r
                 istep = icross_r(i)
-                if (ABS(bhat_mfl(istep - 1)*eta_cross_r(i) - 1.d0) .LT. &
-                    ABS(bhat_mfl(istep)*eta_cross_r(i) - 1.d0)) then
-                    open (111, file='phi_placement_problem.dat', position='append')
-                    write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                        ' step number = ', istep - 1, &
-                        ' 1 / bhat = ', 1.d0/bhat_mfl(istep - 1), &
-                        ' eta = ', eta_cross_r(i)
-                    close (111)
-                    bhat_mfl(istep - 1) = 1/eta_cross_r(i)
-                elseif (ABS(bhat_mfl(istep + 1)*eta_cross_r(i) - 1.d0) .LT. &
-                        ABS(bhat_mfl(istep)*eta_cross_r(i) - 1.d0)) then
-                    open (111, file='phi_placement_problem.dat', position='append')
-                    write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                        ' step number = ', istep + 1, &
-                        ' 1 / bhat = ', 1.d0/bhat_mfl(istep + 1), &
-                        ' eta = ', eta_cross_r(i)
-                    close (111)
-                    bhat_mfl(istep + 1) = 1/eta_cross_r(i)
-                end if
+                bhat_crossing = bhat_mfl(istep)
+                if (istep .GT. ibeg) bhat_crossing(-1) = bhat_mfl(istep - 1)
+                if (istep .LT. iend) bhat_crossing(1) = bhat_mfl(istep + 1)
+                crossing_offset = nearest_phi_crossing_offset( &
+                    bhat_crossing, eta_cross_r(i))
+                aligned_step = istep + crossing_offset
+                open (111, file='phi_placement_problem.dat', position='append')
+                write (111, *) ' propagator tag = ', fieldpropagator%tag, &
+                    ' step number = ', aligned_step, &
+                    ' 1 / bhat = ', 1.d0/bhat_mfl(aligned_step), &
+                    ' eta = ', eta_cross_r(i)
+                close (111)
+                bhat_mfl(aligned_step) = 1.d0/eta_cross_r(i)
             end do
             deallocate (icross_r, eta_cross_r)
         end if

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -3729,11 +3729,12 @@ subroutine fix_phiplacement_problem_old(ibeg,iend,npart,subsqmin,        &
                                     phi_mfl,bhat_mfl,eta)
 
   use device_mod
+  use phi_crossing_alignment_mod, only: nearest_phi_crossing_offset
 
   implicit none
 
   integer :: i,ibeg,iend,npart,istep,ibmin,npassing,npassing_prev
-  integer :: ncross_l,ncross_r,ib,ie
+  integer :: ncross_l,ncross_r,ib,ie,aligned_step,crossing_offset
 
   double precision :: subsqmin
 
@@ -3743,6 +3744,7 @@ subroutine fix_phiplacement_problem_old(ibeg,iend,npart,subsqmin,        &
   double precision, dimension(0:npart)        :: eta
   double precision, dimension(ibeg:iend)      :: phi_mfl,bhat_mfl
   double precision, dimension(:), allocatable :: eta_cross_l,eta_cross_r
+  double precision :: bhat_crossing(-1:1)
 
 ! determine level crossings:
 
@@ -3804,25 +3806,18 @@ subroutine fix_phiplacement_problem_old(ibeg,iend,npart,subsqmin,        &
       enddo
       do i=1,ncross_l
         istep=icross_l(i)
-        if(abs(bhat_mfl(istep-1)*eta_cross_l(i)-1.d0).lt. &
-           abs(bhat_mfl(istep)  *eta_cross_l(i)-1.d0)) then
-          open(111,file='phi_placement_problem.dat',position='append')
-          write(111,*) ' propagator tag = ',fieldpropagator%tag, &
-                       ' step number = ',istep-1,                &
-                       ' 1 / bhat = ',1.d0/bhat_mfl(istep-1),    &
-                       ' eta = ',eta_cross_l(i)
-          close(111)
-          bhat_mfl(istep-1)=1/eta_cross_l(i)
-        elseif(abs(bhat_mfl(istep+1)*eta_cross_l(i)-1.d0).lt. &
-               abs(bhat_mfl(istep)  *eta_cross_l(i)-1.d0)) then
-          open(111,file='phi_placement_problem.dat',position='append')
-          write(111,*) ' propagator tag = ',fieldpropagator%tag, &
-                       ' step number = ',istep+1,                &
-                       ' 1 / bhat = ',1.d0/bhat_mfl(istep+1),    &
-                       ' eta = ',eta_cross_l(i)
-          bhat_mfl(istep+1)=1/eta_cross_l(i)
-          close(111)
-        endif
+        bhat_crossing=bhat_mfl(istep)
+        if(istep.gt.ibeg) bhat_crossing(-1)=bhat_mfl(istep-1)
+        if(istep.lt.iend) bhat_crossing(1)=bhat_mfl(istep+1)
+        crossing_offset=nearest_phi_crossing_offset(bhat_crossing,eta_cross_l(i))
+        aligned_step=istep+crossing_offset
+        open(111,file='phi_placement_problem.dat',position='append')
+        write(111,*) ' propagator tag = ',fieldpropagator%tag, &
+                     ' step number = ',aligned_step,           &
+                     ' 1 / bhat = ',1.d0/bhat_mfl(aligned_step), &
+                     ' eta = ',eta_cross_l(i)
+        close(111)
+        bhat_mfl(aligned_step)=1.d0/eta_cross_l(i)
       enddo
       deallocate(icross_l,eta_cross_l)
     endif
@@ -3881,25 +3876,18 @@ subroutine fix_phiplacement_problem_old(ibeg,iend,npart,subsqmin,        &
       enddo
       do i=1,ncross_r
         istep=icross_r(i)
-        if(abs(bhat_mfl(istep-1)*eta_cross_r(i)-1.d0).lt. &
-           abs(bhat_mfl(istep)  *eta_cross_r(i)-1.d0)) then
-          open(111,file='phi_placement_problem.dat',position='append')
-          write(111,*) ' propagator tag = ',fieldpropagator%tag, &
-                       ' step number = ',istep-1,                &
-                       ' 1 / bhat = ',1.d0/bhat_mfl(istep-1),    &
-                       ' eta = ',eta_cross_r(i)
-          close(111)
-          bhat_mfl(istep-1)=1/eta_cross_r(i)
-        elseif(abs(bhat_mfl(istep+1)*eta_cross_r(i)-1.d0).lt. &
-               abs(bhat_mfl(istep)  *eta_cross_r(i)-1.d0)) then
-          open(111,file='phi_placement_problem.dat',position='append')
-          write(111,*) ' propagator tag = ',fieldpropagator%tag, &
-                       ' step number = ',istep+1,                &
-                       ' 1 / bhat = ',1.d0/bhat_mfl(istep+1),    &
-                       ' eta = ',eta_cross_r(i)
-          close(111)
-          bhat_mfl(istep+1)=1/eta_cross_r(i)
-        endif
+        bhat_crossing=bhat_mfl(istep)
+        if(istep.gt.ibeg) bhat_crossing(-1)=bhat_mfl(istep-1)
+        if(istep.lt.iend) bhat_crossing(1)=bhat_mfl(istep+1)
+        crossing_offset=nearest_phi_crossing_offset(bhat_crossing,eta_cross_r(i))
+        aligned_step=istep+crossing_offset
+        open(111,file='phi_placement_problem.dat',position='append')
+        write(111,*) ' propagator tag = ',fieldpropagator%tag, &
+                     ' step number = ',aligned_step,           &
+                     ' 1 / bhat = ',1.d0/bhat_mfl(aligned_step), &
+                     ' eta = ',eta_cross_r(i)
+        close(111)
+        bhat_mfl(aligned_step)=1.d0/eta_cross_r(i)
       enddo
       deallocate(icross_r,eta_cross_r)
     endif

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -139,6 +139,18 @@ set_tests_properties(phi_placement_diagnostic_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_phi_crossing_alignment test_phi_crossing_alignment.f90)
+target_link_libraries(test_phi_crossing_alignment neo2_ql)
+
+add_test(NAME phi_crossing_alignment_test
+         COMMAND test_phi_crossing_alignment)
+
+set_tests_properties(phi_crossing_alignment_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_join_failure_diagnostic test_join_failure_diagnostic.f90)
 target_link_libraries(test_join_failure_diagnostic neo2_ql)
 

--- a/TEST/test_phi_crossing_alignment.f90
+++ b/TEST/test_phi_crossing_alignment.f90
@@ -1,0 +1,36 @@
+program test_phi_crossing_alignment
+    use, intrinsic :: iso_fortran_env, only: real64
+    use phi_crossing_alignment_mod, only: nearest_phi_crossing_offset
+
+    implicit none
+
+    real(real64), parameter :: eta_cross = 1.0076495897856284_real64
+    real(real64) :: bhat(-1:1)
+    integer :: offset
+
+    bhat = [0.99203602638228305_real64, 0.99274003698367863_real64, &
+        0.99340_real64]
+    offset = nearest_phi_crossing_offset(bhat, eta_cross)
+    if (offset /= 0) &
+        error stop 'FAIL: closest current point was not selected'
+
+    bhat = [1.0_real64/1.00766_real64, 1.0_real64/1.00790_real64, &
+        1.0_real64/1.00820_real64]
+    offset = nearest_phi_crossing_offset(bhat, eta_cross)
+    if (offset /= -1) &
+        error stop 'FAIL: closest preceding point was not selected'
+
+    bhat = [1.0_real64/1.00820_real64, 1.0_real64/1.00790_real64, &
+        1.0_real64/1.00766_real64]
+    offset = nearest_phi_crossing_offset(bhat, eta_cross)
+    if (offset /= 1) &
+        error stop 'FAIL: closest following point was not selected'
+
+    bhat = [1.0_real64/1.00770_real64, 1.0_real64/1.00820_real64, &
+        1.0_real64/1.00766_real64]
+    offset = nearest_phi_crossing_offset(bhat, eta_cross)
+    if (offset /= 1) &
+        error stop 'FAIL: nearest neighbor was not selected'
+
+    print '(a)', 'All tests passed!'
+end program test_phi_crossing_alignment


### PR DESCRIPTION
## Summary

Complete the existing pitch-crossing placement rule by aligning the nearest of
the preceding, current, and following spatial samples to each exact
trapped-passing boundary. The previous rule considered both neighbours but did
nothing when the crossing sample itself was nearest. It could also prefer the
preceding sample without comparing it with a still-closer following sample.

For the band-integrated unknown

\[
Y_k=\int_{\eta_{k-1}}^{\eta_k} f\,d\eta,
\]

a constant distribution is represented by the band width. In the pinned
480-step, 30-band case, propagator 192 changed from 27 to 26 passing bands
between steps 679 and 680. The old placement rule left step 680 unaligned even
though it was the nearest sample. The counter-passing stencil therefore coupled
a width of `3.8755753453293407e-2` to
`3.8419219196663246e-2`. Their difference, multiplied by the streaming
coefficient, produced the complete `5.1395606791432513e-2` constant-state row
residual. The collision terms already cancelled.

The shared selector now performs a true three-point minimum. Both QL solver
variants apply the selected offset, including offset zero. Endpoint crossings
duplicate the current sample for an unavailable neighbour, so the new selector
does not introduce an out-of-bounds access.

This PR is stacked on #163. It uses the opt-in stage trace from that PR to prove
the correction before the diagnostic stack is removed or consolidated.

## Preserved invariants

- The Lorentz collision operator, physical sources, solver tolerance, spatial
  step count, and pitch grid are unchanged.
- Constant `f` is restored as the discrete right null of each single-ripple
  sparse operator.
- Conservative pitch flux, co/counter-passing mirror symmetry, and the existing
  periodic boundary conditions are unchanged.
- Fourier orientation, coordinate conventions, CGS units, ABI, and serialized
  propagator layout are unchanged.
- The intended field-placement operation still changes only one sampled
  `bhat_mfl` value per crossing to `1/eta_cross`; the fix includes the current
  sample and selects the genuinely nearest sample.

The intended sample alignment changes the two reference qflux responses by
`-2.22575e-4` and `-1.53849e-4` relative. Their point-sum closure remains at
roundoff.

## Verification

### Test fails on the stacked base

At `8bf3c29`, the pinned full reconstruction exposes the unresolved constant
state:

```text
$ NEO2_LOCAL_PROJECTION_TRACE_FILE=local_projection_trace.csv \
    sbatch --wait acluster_reconstruction.slurm
Submitted batch job 18572845

sparse_constant, propagator 192, step 679, sigma -1, band 26
absolute residual = 5.1395606791432513e-2
normalized residual = 4.3085458481127306e-3
worst solved-state normalized error = 4.4640034488262030e-3
```

The focused selector regression also fails with the old current-point omission:

```text
$ fo test phi_crossing_alignment_test
phi_crossing_alignment_test                FAIL       0.00s
Summary: 0 passed, 1 failed, 0 skipped
```

### Test passes after fix

```text
$ fo test phi_crossing_alignment_test
phi_crossing_alignment_test                PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped

$ fo
Static: OK (356 modules, 356 changed, 356 affected)
Build: OK
Tests: OK
Lint: OK
Fmt: WARN (legacy solver files)
All stages passed
```

At `f9b0062`, the same pinned reconstruction completes with eight adaptive
solver retries, the same count as the stacked base:

```text
$ NEO2_LOCAL_PROJECTION_TRACE_FILE=local_projection_trace.csv \
    sbatch --wait acluster_reconstruction.slurm
Submitted batch job 18572854

199 local-response files
398 propagator files
199 reconstructed boundaries
worst sparse constant normalized residual = 1.0146656262610906e-16
worst solved-state normalized error = 3.0437079879917021e-14
propagator 192 sparse residual = -1.9755030944423879e-14
propagator 192 solved-state error = 2.7061686225238191e-16
qflux relative closure = 7.837924266104716e-15, 8.250725251683372e-16
periodic compatibility residual = 1.1668851475640071e-16
right-null residual = 1.4689182933004737e-15
transfer matrices: exact identity
adaptive solver retries = 8 (stacked base: 8)
exit status: 0
```

A separate retained stage-0 map trace at the same head verifies the extracted
boundary map after the direct sparse solve:

```text
199 propagators
right-transport normalized residual = 2.2288505877849057e-14
projector-intertwining normalized residual = 2.3275414025818138e-14
left-transport normalized residual = 5.8833256571413954e-15
adaptive solver retries = 4
exit status: 0
```

The retries keep the failure-free resolution campaign open; they do not affect
the before/after localization of the constant-state defect.



## Post-fix convergence status

The localized nullspace fix is necessary but does not establish convergence of
the physical response. A pinned downstream campaign at this head completed at
1920, 3840, and 7680 spatial steps without adaptive recoveries. The local
sparse and solved constant-state residuals, right and left transport, projector
intertwining, qflux reconstruction, and periodic rows remain at floating-point
scale through 7680. Nevertheless, the two harmonic-response components change
by 0.0768% and 0.0612% at the first doubling, then by 4.05% and 3.07% at the
second. An `epserr_iter` scan from `1e-4` through `1e-6` is bitwise identical,
so iteration tolerance does not explain the change.

A point-resolved 3840--7680 comparison also rules out one isolated propagator.
For each response component, 127 of 199 propagators are required to accumulate
90% of the change, no propagator supplies more than 1%, and the signed change
agrees with the sum of absolute changes to better than `3e-10`. The
per-propagator pitch-topology signatures and the crossing-boundary `eta`
sequence are unchanged.

The remaining leading risk is the pre-existing placement operation, not the
three-point selector introduced here. `fix_phiplacement_problem_old` replaces
only `bhat_mfl(aligned_step)` by `1/eta_cross`; it leaves `phi_mfl`,
`geodcu_mfl`, `h_phi_mfl`, and `dlogbdphi_mfl` sampled at the original point.
The selected point moves under spatial refinement. This identifies a
geometry-consistency risk but is not yet a causal proof. A follow-up must derive
either a root-aligned grid or a consistent resampling rule and preserve the
physical field, pitch-band measure, constant-distribution right null, particle
left null, source quadrature, mirror and periodic boundaries, units, ABI, and
serialized layout.

Accordingly, this PR remains the focused correction for the current-point
omission and true nearest-sample selection. It is stacked on #163 and should
remain unmerged while the geometry-preserving follow-up is derived and the
three-level spatial and pitch screens are repeated. No physical current profile
is accepted from the present campaign.

## Field-preserving follow-up contract

A subsequent 30/60/120-band scan rejects the physical response even though the corrected local algebra remains close to roundoff. From 60 to 120 bands, the two response components change by `3.34556e-3` and `3.84088e-3`, above the `1e-3` gate. The 60-band run needs four adaptive recoveries, and the 120-band solved-constant residual is `2.22873e-11`, above its `1e-11` tolerance. No response profile is accepted from this PR.

An independent symbolic derivation now fixes the contract for the follow-up. For each pitch boundary, solve the simple bracketed root `1 - eta B(phi*) = 0` and move an interior spatial node to `phi*`; do not overwrite only `B` at a fixed point. Evaluate all primitive field, metric, drift, and derivative data at the same root, then recompute every dependent coefficient and nonuniform cell factor. The pitch-band measure must remain unchanged. A lost or non-simple root, or two crossings competing for one node, requires refinement or rejection. A fixed-node-count move preserves the current ABI and serialized propagator layout; insertion requires an explicit format migration.

The derivation verifies the crossing and derivative identities, vanishing mirror factor, unchanged pitch measure, conservative nonuniform flux telescoping, constant-source quadrature, periodic endpoints, unit scaling, and crossing-conflict rejection. Implementation still must re-establish the constant-distribution right null, particle left null, mirror and periodic rows, source quadrature, qflux, and three-level spatial and pitch convergence. This PR remains a narrowly scoped nearest-sample correction and must not be treated as the geometry-preserving follow-up.