### PR TITLE
Preserve geometry at pitch crossings

### DIFF
--- a/NEO-2-QL/phi_crossing_alignment_mod.f90
+++ b/NEO-2-QL/phi_crossing_alignment_mod.f90
@@ -1,7 +1,20 @@
 module phi_crossing_alignment_mod
     use, intrinsic :: iso_fortran_env, only: dp => real64
+    use plagrange_mod, only: plagrange_coeff
 
     implicit none
+
+    private
+
+    integer, parameter, public :: crossing_ok = 0
+    integer, parameter, public :: crossing_no_bracket = 1
+    integer, parameter, public :: crossing_non_simple = 2
+    integer, parameter, public :: crossing_invalid_stencil = 3
+    integer, parameter :: crossing_stencil_size = 6
+
+    public :: bracketed_phi_crossing
+    public :: claim_crossing_target
+    public :: nearest_phi_crossing_offset
 
 contains
 
@@ -17,5 +30,173 @@ contains
         if (residual(-1) < residual(offset)) offset = -1
         if (residual(1) < residual(offset)) offset = 1
     end function nearest_phi_crossing_offset
+
+    subroutine bracketed_phi_crossing(ibeg, iend, phi, bhat, bracket_left, &
+            eta_cross, phi_cross, stencil_left, &
+            weights, derivative_weights, target, status)
+        integer, intent(in) :: ibeg, iend, bracket_left
+        real(dp), intent(in) :: phi(ibeg:iend), bhat(ibeg:iend)
+        real(dp), intent(in) :: eta_cross
+        real(dp), intent(out) :: phi_cross
+        integer, intent(out) :: stencil_left, target, status
+        real(dp), intent(out) :: weights(crossing_stencil_size)
+        real(dp), intent(out) :: derivative_weights(crossing_stencil_size)
+
+        integer, parameter :: maximum_iterations = 100
+        integer, parameter :: monotonic_samples = 9
+        real(dp) :: bhat_cross, bhat_derivative, bhat_scale, derivative_scale
+        real(dp) :: derivative_reference, f_cross, f_left, f_right
+        real(dp) :: left, phi_scale, phi_tolerance, right, sample_phi
+        real(dp) :: value_tolerance
+        integer :: iteration, sample
+
+        phi_cross = 0.0_dp
+        stencil_left = ibeg
+        target = ibeg
+        status = crossing_invalid_stencil
+        weights = 0.0_dp
+        derivative_weights = 0.0_dp
+
+        if (iend - ibeg + 1 < crossing_stencil_size) return
+        if (bracket_left < ibeg .or. bracket_left >= iend) return
+        if (eta_cross <= 0.0_dp) return
+        if (any(phi(ibeg + 1:iend) <= phi(ibeg:iend - 1))) return
+
+        stencil_left = max(ibeg, min(iend - crossing_stencil_size + 1, &
+            bracket_left - crossing_stencil_size/2 + 1))
+        left = phi(bracket_left)
+        right = phi(bracket_left + 1)
+        phi_scale = max(1.0_dp, abs(left), abs(right))
+        phi_tolerance = 128.0_dp*epsilon(1.0_dp)*phi_scale
+        bhat_scale = max(1.0_dp, &
+            maxval(abs(bhat(stencil_left: &
+            stencil_left + crossing_stencil_size - 1))))
+        value_tolerance = 128.0_dp*epsilon(1.0_dp)*bhat_scale*eta_cross
+        derivative_scale = 128.0_dp*epsilon(1.0_dp)*bhat_scale/(right - left)
+
+        call evaluate_profile(left, &
+            phi(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat_cross, bhat_derivative, weights, &
+            derivative_weights)
+        f_left = 1.0_dp - eta_cross*bhat_cross
+        derivative_reference = bhat_derivative
+        if (abs(derivative_reference) <= derivative_scale) then
+            status = crossing_non_simple
+            return
+        end if
+
+        call evaluate_profile(right, &
+            phi(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat_cross, bhat_derivative, weights, &
+            derivative_weights)
+        f_right = 1.0_dp - eta_cross*bhat_cross
+        if (abs(bhat_derivative) <= derivative_scale .or. &
+            bhat_derivative*derivative_reference <= 0.0_dp) then
+            status = crossing_non_simple
+            return
+        end if
+
+        do sample = 1, monotonic_samples - 2
+            sample_phi = left + (right - left)*real(sample, dp)/ &
+                real(monotonic_samples - 1, dp)
+            call evaluate_profile(sample_phi, &
+                phi(stencil_left:stencil_left + crossing_stencil_size - 1), &
+                bhat(stencil_left:stencil_left + crossing_stencil_size - 1), &
+                bhat_cross, bhat_derivative, weights, &
+                derivative_weights)
+            if (abs(bhat_derivative) <= derivative_scale .or. &
+                bhat_derivative*derivative_reference <= 0.0_dp) then
+                status = crossing_non_simple
+                return
+            end if
+        end do
+
+        if (abs(f_left) <= value_tolerance) then
+            phi_cross = left
+        else if (abs(f_right) <= value_tolerance) then
+            phi_cross = right
+        else
+            if (f_left*f_right >= 0.0_dp) then
+                status = crossing_no_bracket
+                return
+            end if
+            do iteration = 1, maximum_iterations
+                phi_cross = 0.5_dp*(left + right)
+                call evaluate_profile(phi_cross, &
+                    phi(stencil_left:stencil_left + crossing_stencil_size - 1), &
+                    bhat(stencil_left:stencil_left + crossing_stencil_size - 1), &
+                    bhat_cross, bhat_derivative, weights, &
+                    derivative_weights)
+                f_cross = 1.0_dp - eta_cross*bhat_cross
+                if (abs(f_cross) <= value_tolerance .or. &
+                    right - left <= phi_tolerance) exit
+                if (f_left*f_cross < 0.0_dp) then
+                    right = phi_cross
+                    f_right = f_cross
+                else
+                    left = phi_cross
+                    f_left = f_cross
+                end if
+            end do
+        end if
+
+        call evaluate_profile(phi_cross, &
+            phi(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat(stencil_left:stencil_left + crossing_stencil_size - 1), &
+            bhat_cross, bhat_derivative, weights, &
+            derivative_weights)
+        if (abs(bhat_derivative) <= derivative_scale) then
+            status = crossing_non_simple
+            return
+        end if
+
+        if (abs(phi_cross - phi(bracket_left)) <= phi_tolerance) then
+            target = bracket_left
+        else if (abs(phi_cross - phi(bracket_left + 1)) <= phi_tolerance) then
+            target = bracket_left + 1
+        else if (phi_cross - phi(bracket_left) <= &
+                phi(bracket_left + 1) - phi_cross) then
+            target = bracket_left
+        else
+            target = bracket_left + 1
+        end if
+        if (target == ibeg .and. phi_cross > phi(ibeg) + phi_tolerance) &
+            target = ibeg + 1
+        if (target == iend .and. phi_cross < phi(iend) - phi_tolerance) &
+            target = iend - 1
+        status = crossing_ok
+    end subroutine bracketed_phi_crossing
+
+    logical function claim_crossing_target(claimed, target) result(accepted)
+        logical, intent(inout) :: claimed(0:)
+        integer, intent(in) :: target
+
+        accepted = .false.
+        if (target < lbound(claimed, 1) .or. target > ubound(claimed, 1)) return
+        if (claimed(target)) return
+        claimed(target) = .true.
+        accepted = .true.
+    end function claim_crossing_target
+
+    subroutine evaluate_profile(phi_value, phi, bhat, &
+            bhat_value, bhat_derivative, weights, &
+            derivative_weights)
+        real(dp), intent(in) :: phi_value
+        real(dp), intent(in) :: phi(crossing_stencil_size)
+        real(dp), intent(in) :: bhat(crossing_stencil_size)
+        real(dp), intent(out) :: bhat_value, bhat_derivative
+        real(dp), intent(out) :: weights(crossing_stencil_size)
+        real(dp), intent(out) :: derivative_weights(crossing_stencil_size)
+
+        real(dp) :: coefficients(0:1, crossing_stencil_size)
+        call plagrange_coeff(crossing_stencil_size, 1, phi_value, &
+            phi, coefficients)
+        weights = coefficients(0, :)
+        derivative_weights = coefficients(1, :)
+        bhat_value = sum(weights*bhat)
+        bhat_derivative = sum(derivative_weights*bhat)
+    end subroutine evaluate_profile
 
 end module phi_crossing_alignment_mod

--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -800,6 +800,37 @@ subroutine ripple_solver_ArnoldiO2( &
     !! End Modifications by Andreas F. Martitsch (14.03.2014)
     end if
 
+    subsqmin = 1.d5*EPSILON(1.d0)
+    allocate (delt_pos(ibeg:iend), delt_neg(ibeg:iend))
+    allocate (fact_pos_b(ibeg:iend), fact_neg_b(ibeg:iend))
+    allocate (fact_pos_e(ibeg:iend), fact_neg_e(ibeg:iend))
+
+    nreal = 3
+    ncomp = 1
+    allocate (arr_real(ibeg:iend, nreal), arr_comp(ibeg:iend, ncomp))
+    arr_real(:, 1) = h_phi_mfl
+    arr_real(:, 2) = dlogbds_mfl
+    arr_real(:, 3) = bcovar_s_hat_mfl
+    arr_comp(:, 1) = geodcu_mfl
+
+    call rearrange_phideps(ibeg, iend, npart, ncomp, nreal, 3, subsqmin, &
+                           phi_divide, phi_mfl, bhat_mfl, dlogbdphi_mfl, &
+                           dbcovar_s_hat_dphi_mfl, arr_real, arr_comp, eta, &
+                           delt_pos, delt_neg, fact_pos_b, fact_neg_b, &
+                           fact_pos_e, fact_neg_e)
+
+    h_phi_mfl = arr_real(:, 1)
+    dlogbds_mfl = arr_real(:, 2)
+    bcovar_s_hat_mfl = arr_real(:, 3)
+    geodcu_mfl = arr_comp(:, 1)
+    deallocate (arr_real, arr_comp)
+
+    if (maxval(phi_divide) > 1) then
+        ierr = 3
+        write (*, *) 'ERROR: crossing geometry requires phi refinement.'
+        return
+    end if
+
     ! Computation of the perturbed quantities without
     ! usage of interfaces (fieldpropagator-structure,...)
     if (isw_qflux_na .ne. 0) then
@@ -993,42 +1024,6 @@ subroutine ripple_solver_ArnoldiO2( &
     allocate (amat(ndim, ndim), bvec_lapack(ndim, ndim), ipivot(ndim))
 
     npart_loc = 0
-    subsqmin = 1.d5*EPSILON(1.d0)
-
-    allocate (delt_pos(ibeg:iend), delt_neg(ibeg:iend))
-    allocate (fact_pos_b(ibeg:iend), fact_neg_b(ibeg:iend))
-    allocate (fact_pos_e(ibeg:iend), fact_neg_e(ibeg:iend))
-
-    nreal = 1
-    ncomp = 1
-    allocate (arr_real(ibeg:iend, nreal), arr_comp(ibeg:iend, ncomp))
-    arr_real(:, 1) = h_phi_mfl
-    arr_comp(:, 1) = geodcu_mfl
-
-    call rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divide, &
-                           phi_mfl, bhat_mfl, arr_real, arr_comp, eta, &
-                           delt_pos, delt_neg, &
-                           fact_pos_b, fact_neg_b, fact_pos_e, fact_neg_e)
-
-    h_phi_mfl = arr_real(:, 1)
-    geodcu_mfl = arr_comp(:, 1)
-    deallocate (arr_real, arr_comp)
-
-    ! Consistency check of phi_divide, ifnot sucessful, return from this
-    ! subroutine.
-    if (maxval(phi_divide) > 1) then
-        ierr = 3
-        deallocate (deriv_coef, npl)
-        deallocate (rhs_mat_lorentz, rhs_mat_energ)
-        deallocate (fun_coef, ttmp_mat)
-        deallocate (rhs_mat_energ2)        !NTV
-        deallocate (q_rip, q_rip_1, q_rip_incompress, q_rip_parflow)
-        deallocate (q_hel_b, q_hel_e)
-        deallocate (convol_flux, convol_curr, convol_flux_0)
-        deallocate (pleg_bra, pleg_ket, scalprod_pleg)
-        write (*, *) 'ERROR: maxval(phi_divide) > 1, returning.'
-        return
-    end if
 
     do istep = ibeg, iend
 
@@ -4942,8 +4937,10 @@ end subroutine ripple_solver_ArnoldiO2
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !! Modifications by Andreas F. Martitsch (27.07.2015)
 ! Multiple definitions avoided
-subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divide, &
-                             phi_mfl, bhat_mfl, arr_real, arr_comp, eta, &
+subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
+                             subsqmin, phi_divide, phi_mfl, bhat_mfl, &
+                             dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
+                             arr_real, arr_comp, eta, &
                              delt_pos, delt_neg, &
                              fact_pos_b, fact_neg_b, fact_pos_e, fact_neg_e)
 
@@ -4953,18 +4950,18 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
 ! fact_neg_b(i) - integration step in negative direction starts at point i
 ! fact_neg_e(i) - integration step in negative direction ends at point i
 
-    use plagrange_mod
+    use plagrange_mod, only: plagrange_coeff
 
     implicit none
 
     integer, parameter :: dp = kind(1.0d0)
 
     logical, parameter :: stepmode = .FALSE.
-    integer, parameter :: npoi = 6, nder = 0, npoihalf = npoi/2, nstepmin = 8
+    integer, parameter :: npoi = 6, nder = 1, npoihalf = npoi/2, nstepmin = 8
     real(dp), parameter :: bparabmax = 0.2d0
 
     integer :: i, ibeg, iend, npart, istep, ibmin, npassing, npassing_prev
-    integer :: ncomp, nreal
+    integer :: ncomp, nreal, bcovar_column, failed_interval
     integer :: ncross_l, ncross_r, ib, ie, intb, inte, k, imid, isplit
 
     real(dp) :: subsqmin, ht, ht2, bparab, x1, x2, f1, f2
@@ -4976,21 +4973,31 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
     real(dp), dimension(0:nder, npoi)      :: coeff
     real(dp), dimension(0:npart)          :: eta
     real(dp), dimension(ibeg:iend)        :: phi_mfl, bhat_mfl
+    real(dp), dimension(ibeg:iend)        :: dlogbdphi_mfl
+    real(dp), dimension(ibeg:iend)        :: dbcovar_s_hat_dphi_mfl
     real(dp), dimension(ibeg:iend, nreal)  :: arr_real
     complex(dp), dimension(ibeg:iend, ncomp)  :: arr_comp
     real(dp), dimension(ibeg:iend)        :: delt_pos, delt_neg
     real(dp), dimension(ibeg:iend)        :: fact_pos_b, fact_neg_b
     real(dp), dimension(ibeg:iend)        :: fact_pos_e, fact_neg_e
     real(dp), dimension(:), allocatable   :: phi_new, bhat_new
+    real(dp), dimension(:), allocatable   :: dlogbdphi_new
+    real(dp), dimension(:), allocatable   :: dbcovar_s_hat_dphi_new
     real(dp), dimension(:, :), allocatable :: arr_real_new
     complex(dp), dimension(:, :), allocatable :: arr_comp_new
 
     npassing = -1
 
-    call fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
-                                  phi_mfl, bhat_mfl, eta)
-
     phi_divide = 1
+    call align_phi_crossing_geometry(ibeg, iend, npart, ncomp, nreal, &
+                                     ubound(phi_divide, 1), bcovar_column, &
+                                     subsqmin, phi_mfl, bhat_mfl, &
+                                     dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
+                                     arr_real, arr_comp, eta, failed_interval)
+    if (failed_interval > 0) then
+        phi_divide(failed_interval) = 2
+        return
+    end if
 
     delt_pos(ibeg + 1:iend) = phi_mfl(ibeg + 1:iend) - phi_mfl(ibeg:iend - 1)
     fact_pos_b = 1.d0
@@ -5182,10 +5189,13 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
     if (stepmode) then
 
         allocate (phi_new(ibeg:iend), bhat_new(ibeg:iend))
+        allocate (dlogbdphi_new(ibeg:iend), dbcovar_s_hat_dphi_new(ibeg:iend))
         allocate (arr_real_new(ibeg:iend, nreal))
         allocate (arr_comp_new(ibeg:iend, ncomp))
         phi_new = phi_mfl
         bhat_new = bhat_mfl
+        dlogbdphi_new = dlogbdphi_mfl
+        dbcovar_s_hat_dphi_new = dbcovar_s_hat_dphi_mfl
         arr_real_new = arr_real
         arr_comp_new = arr_comp
 
@@ -5208,6 +5218,12 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
                 call plagrange_coeff(npoi, nder, phi_new(istep), phi_mfl(intb:inte), coeff)
 
                 bhat_new(istep) = SUM(coeff(0, :)*bhat_mfl(intb:inte))
+                dlogbdphi_new(istep) = &
+                    SUM(coeff(1, :)*bhat_mfl(intb:inte))/bhat_new(istep)
+                if (bcovar_column > 0) then
+                    dbcovar_s_hat_dphi_new(istep) = &
+                        SUM(coeff(1, :)*arr_real(intb:inte, bcovar_column))
+                end if
                 arr_real_new(istep, :) = MATMUL(coeff(0, :), arr_real(intb:inte, :))
                 arr_comp_new(istep, :) = MATMUL(coeff(0, :), arr_comp(intb:inte, :))
             end do
@@ -5237,6 +5253,12 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
                 call plagrange_coeff(npoi, nder, phi_new(istep), phi_mfl(intb:inte), coeff)
 
                 bhat_new(istep) = SUM(coeff(0, :)*bhat_mfl(intb:inte))
+                dlogbdphi_new(istep) = &
+                    SUM(coeff(1, :)*bhat_mfl(intb:inte))/bhat_new(istep)
+                if (bcovar_column > 0) then
+                    dbcovar_s_hat_dphi_new(istep) = &
+                        SUM(coeff(1, :)*arr_real(intb:inte, bcovar_column))
+                end if
                 arr_real_new(istep, :) = MATMUL(coeff(0, :), arr_real(intb:inte, :))
                 arr_comp_new(istep, :) = MATMUL(coeff(0, :), arr_comp(intb:inte, :))
             end do
@@ -5249,10 +5271,13 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
 
         phi_mfl = phi_new
         bhat_mfl = bhat_new
+        dlogbdphi_mfl = dlogbdphi_new
+        dbcovar_s_hat_dphi_mfl = dbcovar_s_hat_dphi_new
         arr_real = arr_real_new
         arr_comp = arr_comp_new
 
-        deallocate (phi_new, bhat_new, arr_real_new, arr_comp_new)
+        deallocate (phi_new, bhat_new, dlogbdphi_new, &
+                    dbcovar_s_hat_dphi_new, arr_real_new, arr_comp_new)
 
     end if
 
@@ -5266,177 +5291,148 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, subsqmin, phi_divi
 end subroutine rearrange_phideps
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-subroutine fix_phiplacement_problem(ibeg, iend, npart, subsqmin, &
-                                    phi_mfl, bhat_mfl, eta)
+subroutine align_phi_crossing_geometry(ibeg, iend, npart, ncomp, nreal, ub_mag, &
+                                       bcovar_column, subsqmin, phi_mfl, &
+                                       bhat_mfl, dlogbdphi_mfl, &
+                                       dbcovar_s_hat_dphi_mfl, arr_real, &
+                                       arr_comp, eta, failed_interval)
 
-    use device_mod
-    use phi_crossing_alignment_mod, only: nearest_phi_crossing_offset
+    use device_mod, only: fieldpropagator
+    use phi_crossing_alignment_mod, only: bracketed_phi_crossing, &
+        claim_crossing_target, crossing_ok
 
     implicit none
 
     integer, parameter :: dp = kind(1.0d0)
+    integer, parameter :: stencil_size = 6
 
-    integer :: i, ibeg, iend, npart, istep, ibmin, npassing, npassing_prev
-    integer :: aligned_step, crossing_offset, ncross_l, ncross_r
+    integer, intent(in) :: ibeg, iend, npart, ncomp, nreal, ub_mag, bcovar_column
+    real(dp), intent(in) :: subsqmin
+    real(dp), intent(inout) :: phi_mfl(ibeg:iend), bhat_mfl(ibeg:iend)
+    real(dp), intent(inout) :: dlogbdphi_mfl(ibeg:iend)
+    real(dp), intent(inout) :: dbcovar_s_hat_dphi_mfl(ibeg:iend)
+    real(dp), intent(inout) :: arr_real(ibeg:iend, nreal)
+    complex(dp), intent(inout) :: arr_comp(ibeg:iend, ncomp)
+    real(dp), intent(in) :: eta(0:npart)
+    integer, intent(out) :: failed_interval
 
-    real(dp) :: subsqmin
+    complex(dp) :: arr_comp_original(ibeg:iend, ncomp)
+    real(dp) :: arr_real_original(ibeg:iend, nreal)
+    real(dp) :: bhat_original(ibeg:iend), phi_original(ibeg:iend)
+    real(dp) :: crossing_eta(2*(npart + 1)), crossing_phi(2*(npart + 1))
+    real(dp) :: derivative_weights(stencil_size, 2*(npart + 1))
+    real(dp) :: weights(stencil_size, 2*(npart + 1))
+    integer :: bracket_left(2*(npart + 1)), crossing_target(2*(npart + 1))
+    integer :: stencil_left(2*(npart + 1))
+    integer :: i, ibmin, istep, ncross, npassing, npassing_previous
+    integer :: root_status
+    logical :: claimed(0:iend)
 
-    integer, dimension(1)              :: idummy
-    integer, dimension(:), allocatable :: icross_l, icross_r
+    failed_interval = 0
+    phi_original = phi_mfl
+    bhat_original = bhat_mfl
+    arr_real_original = arr_real
+    arr_comp_original = arr_comp
+    claimed = .false.
+    ncross = 0
 
-    real(dp), dimension(0:npart)        :: eta
-    real(dp), dimension(ibeg:iend)      :: phi_mfl, bhat_mfl
-    real(dp), dimension(:), allocatable :: eta_cross_l, eta_cross_r
-    real(dp) :: bhat_crossing(-1:1)
-
-    npassing = -1
-
-! determine level crossings:
-
-    idummy = MINLOC(bhat_mfl(ibeg:iend))
-    ibmin = idummy(1) + ibeg - 1
-
-    ncross_l = 0
-    if (ibmin .GT. ibeg) then
-        istep = ibmin
-        do i = 0, npart
-            if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                npassing = i
-            else
-                EXIT
-            end if
-        end do
-        npassing_prev = npassing
-        do istep = ibmin - 1, ibeg, -1
-            do i = 0, npart
-                if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                    npassing = i
-                else
-                    EXIT
-                end if
-            end do
-            if (npassing .LT. npassing_prev) then
-                ncross_l = ncross_l + 1
-                npassing_prev = npassing
-            end if
-        end do
-        if (ncross_l .GT. 0) then
-            allocate (icross_l(ncross_l), eta_cross_l(ncross_l))
-            ncross_l = 0
-            istep = ibmin
-            do i = 0, npart
-                if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                    npassing = i
-                else
-                    EXIT
-                end if
-            end do
-            npassing_prev = npassing
-            do istep = ibmin - 1, ibeg, -1
-                do i = 0, npart
-                    if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                        npassing = i
-                    else
-                        EXIT
-                    end if
-                end do
-                if (npassing .LT. npassing_prev) then
-                    ncross_l = ncross_l + 1
-                    icross_l(ncross_l) = istep
-                    eta_cross_l(ncross_l) = eta(npassing_prev)
-                    npassing_prev = npassing
-                end if
-            end do
-            do i = 1, ncross_l
-                istep = icross_l(i)
-                bhat_crossing = bhat_mfl(istep)
-                if (istep .GT. ibeg) bhat_crossing(-1) = bhat_mfl(istep - 1)
-                if (istep .LT. iend) bhat_crossing(1) = bhat_mfl(istep + 1)
-                crossing_offset = nearest_phi_crossing_offset( &
-                    bhat_crossing, eta_cross_l(i))
-                aligned_step = istep + crossing_offset
-                open (111, file='phi_placement_problem.dat', position='append')
-                write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                    ' step number = ', aligned_step, &
-                    ' 1 / bhat = ', 1.d0/bhat_mfl(aligned_step), &
-                    ' eta = ', eta_cross_l(i)
-                close (111)
-                bhat_mfl(aligned_step) = 1.d0/eta_cross_l(i)
-            end do
-            deallocate (icross_l, eta_cross_l)
+    ibmin = minloc(bhat_original(0:ub_mag), dim=1) - 1
+    npassing_previous = passing_index(bhat_original(ibmin))
+    do istep = ibmin - 1, 0, -1
+        npassing = passing_index(bhat_original(istep))
+        if (npassing > npassing_previous) then
+            call reject_interval(istep)
+            return
         end if
-    end if
-
-    ncross_r = 0
-    if (ibmin .LT. iend) then
-        istep = ibmin
-        do i = 0, npart
-            if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                npassing = i
-            else
-                EXIT
+        if (npassing < npassing_previous) then
+            if (npassing_previous - npassing /= 1) then
+                call reject_interval(istep)
+                return
             end if
-        end do
-        npassing_prev = npassing
-        do istep = ibmin + 1, iend
-            do i = 0, npart
-                if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                    npassing = i
-                else
-                    EXIT
-                end if
-            end do
-            if (npassing .LT. npassing_prev) then
-                ncross_r = ncross_r + 1
-                npassing_prev = npassing
-            end if
-        end do
-        if (ncross_r .GT. 0) then
-            allocate (icross_r(ncross_r), eta_cross_r(ncross_r))
-            ncross_r = 0
-            istep = ibmin
-            do i = 0, npart
-                if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                    npassing = i
-                else
-                    EXIT
-                end if
-            end do
-            npassing_prev = npassing
-            do istep = ibmin + 1, iend
-                do i = 0, npart
-                    if (1.d0 - bhat_mfl(istep)*eta(i) .GT. subsqmin) then
-                        npassing = i
-                    else
-                        EXIT
-                    end if
-                end do
-                if (npassing .LT. npassing_prev) then
-                    ncross_r = ncross_r + 1
-                    icross_r(ncross_r) = istep
-                    eta_cross_r(ncross_r) = eta(npassing_prev)
-                    npassing_prev = npassing
-                end if
-            end do
-            do i = 1, ncross_r
-                istep = icross_r(i)
-                bhat_crossing = bhat_mfl(istep)
-                if (istep .GT. ibeg) bhat_crossing(-1) = bhat_mfl(istep - 1)
-                if (istep .LT. iend) bhat_crossing(1) = bhat_mfl(istep + 1)
-                crossing_offset = nearest_phi_crossing_offset( &
-                    bhat_crossing, eta_cross_r(i))
-                aligned_step = istep + crossing_offset
-                open (111, file='phi_placement_problem.dat', position='append')
-                write (111, *) ' propagator tag = ', fieldpropagator%tag, &
-                    ' step number = ', aligned_step, &
-                    ' 1 / bhat = ', 1.d0/bhat_mfl(aligned_step), &
-                    ' eta = ', eta_cross_r(i)
-                close (111)
-                bhat_mfl(aligned_step) = 1.d0/eta_cross_r(i)
-            end do
-            deallocate (icross_r, eta_cross_r)
+            ncross = ncross + 1
+            bracket_left(ncross) = istep
+            crossing_eta(ncross) = eta(npassing_previous)
+            npassing_previous = npassing
         end if
-    end if
+    end do
 
-end subroutine fix_phiplacement_problem
+    npassing_previous = passing_index(bhat_original(ibmin))
+    do istep = ibmin + 1, ub_mag
+        npassing = passing_index(bhat_original(istep))
+        if (npassing > npassing_previous) then
+            call reject_interval(istep - 1)
+            return
+        end if
+        if (npassing < npassing_previous) then
+            if (npassing_previous - npassing /= 1) then
+                call reject_interval(istep - 1)
+                return
+            end if
+            ncross = ncross + 1
+            bracket_left(ncross) = istep - 1
+            crossing_eta(ncross) = eta(npassing_previous)
+            npassing_previous = npassing
+        end if
+    end do
+
+    do i = 1, ncross
+        call bracketed_phi_crossing(0, ub_mag, phi_original(0:ub_mag), &
+            bhat_original(0:ub_mag), bracket_left(i), crossing_eta(i), &
+            crossing_phi(i), stencil_left(i), weights(:, i), &
+            derivative_weights(:, i), crossing_target(i), root_status)
+        if (root_status /= crossing_ok) then
+            call reject_interval(bracket_left(i))
+            return
+        end if
+        if (.not. claim_crossing_target(claimed, crossing_target(i))) then
+            call reject_interval(bracket_left(i))
+            return
+        end if
+    end do
+
+    do i = 1, ncross
+        istep = crossing_target(i)
+        phi_mfl(istep) = crossing_phi(i)
+        bhat_mfl(istep) = 1.0_dp/crossing_eta(i)
+        arr_real(istep, :) = matmul(weights(:, i), &
+            arr_real_original(stencil_left(i):stencil_left(i) + stencil_size - 1, :))
+        arr_comp(istep, :) = matmul(weights(:, i), &
+            arr_comp_original(stencil_left(i):stencil_left(i) + stencil_size - 1, :))
+        dlogbdphi_mfl(istep) = sum(derivative_weights(:, i)* &
+            bhat_original(stencil_left(i):stencil_left(i) + stencil_size - 1))/ &
+            bhat_mfl(istep)
+        if (bcovar_column > 0) then
+            dbcovar_s_hat_dphi_mfl(istep) = sum(derivative_weights(:, i)* &
+                arr_real_original(stencil_left(i): &
+                                  stencil_left(i) + stencil_size - 1, &
+                                  bcovar_column))
+        end if
+        open (111, file='phi_placement_problem.dat', position='append')
+        write (111, *) ' propagator tag = ', fieldpropagator%tag, &
+            ' step number = ', istep, ' phi = ', phi_mfl(istep), &
+            ' eta = ', crossing_eta(i)
+        close (111)
+    end do
+
+contains
+
+    integer function passing_index(bhat_value) result(index)
+        real(dp), intent(in) :: bhat_value
+
+        integer :: band
+
+        index = -1
+        do band = 0, npart
+            if (1.0_dp - bhat_value*eta(band) <= subsqmin) exit
+            index = band
+        end do
+    end function passing_index
+
+    subroutine reject_interval(left_index)
+        integer, intent(in) :: left_index
+
+        failed_interval = max(1, min(ub_mag, left_index + 1))
+    end subroutine reject_interval
+
+end subroutine align_phi_crossing_geometry
 !! End Modifications by Andreas F. Martitsch (27.07.2015)

--- a/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
+++ b/NEO-2-QL/ripple_solver_ArnoldiOrder2_test.f90
@@ -813,7 +813,7 @@ subroutine ripple_solver_ArnoldiO2( &
     arr_real(:, 3) = bcovar_s_hat_mfl
     arr_comp(:, 1) = geodcu_mfl
 
-    call rearrange_phideps(ibeg, iend, npart, ncomp, nreal, 3, subsqmin, &
+    call rearrange_phideps(ibeg, iend, ub_mag, npart, ncomp, nreal, 3, subsqmin, &
                            phi_divide, phi_mfl, bhat_mfl, dlogbdphi_mfl, &
                            dbcovar_s_hat_dphi_mfl, arr_real, arr_comp, eta, &
                            delt_pos, delt_neg, fact_pos_b, fact_neg_b, &
@@ -4937,9 +4937,9 @@ end subroutine ripple_solver_ArnoldiO2
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !! Modifications by Andreas F. Martitsch (27.07.2015)
 ! Multiple definitions avoided
-subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
-                             subsqmin, phi_divide, phi_mfl, bhat_mfl, &
-                             dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
+subroutine rearrange_phideps(ibeg, iend, ub_mag, npart, ncomp, nreal, &
+                             bcovar_column, subsqmin, phi_divide, phi_mfl, &
+                             bhat_mfl, dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
                              arr_real, arr_comp, eta, &
                              delt_pos, delt_neg, &
                              fact_pos_b, fact_neg_b, fact_pos_e, fact_neg_e)
@@ -4960,6 +4960,8 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
     integer, parameter :: npoi = 6, nder = 1, npoihalf = npoi/2, nstepmin = 8
     real(dp), parameter :: bparabmax = 0.2d0
 
+    integer, intent(in) :: ub_mag
+
     integer :: i, ibeg, iend, npart, istep, ibmin, npassing, npassing_prev
     integer :: ncomp, nreal, bcovar_column, failed_interval
     integer :: ncross_l, ncross_r, ib, ie, intb, inte, k, imid, isplit
@@ -4967,7 +4969,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
     real(dp) :: subsqmin, ht, ht2, bparab, x1, x2, f1, f2
 
     integer, dimension(1)              :: idummy
-    integer, dimension(1:iend)         :: phi_divide
+    integer, dimension(1:ub_mag)       :: phi_divide
     integer, dimension(:), allocatable :: icross_l, icross_r
 
     real(dp), dimension(0:nder, npoi)      :: coeff
@@ -4990,7 +4992,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
 
     phi_divide = 1
     call align_phi_crossing_geometry(ibeg, iend, npart, ncomp, nreal, &
-                                     ubound(phi_divide, 1), bcovar_column, &
+                                     ub_mag, bcovar_column, &
                                      subsqmin, phi_mfl, bhat_mfl, &
                                      dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
                                      arr_real, arr_comp, eta, failed_interval)
@@ -5145,7 +5147,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
                 bparab = ABS((f1*x2 - f2*x1)*x2/((x1 - x2)*x1*f2))
                 if (bparab .GT. bparabmax) then
                     isplit = 2*MAX(NINT(0.5*float(nstepmin)/float(ie - ib)), 1)
-                    phi_divide(ib + 1:ie) = isplit
+                    phi_divide(max(1, ib + 1):min(ie, ub_mag)) = isplit
                 end if
             end if
             ie = ib
@@ -5153,7 +5155,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
         ib = ibeg
         if (ie - ib .LT. nstepmin) then
             isplit = 2*MAX(NINT(0.5*float(nstepmin)/float(ie - ib)), 1)
-            phi_divide(ib + 1:ie) = isplit
+            phi_divide(max(1, ib + 1):min(ie, ub_mag)) = isplit
         end if
     end if
 
@@ -5170,7 +5172,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
                 bparab = ABS((f1*x2 - f2*x1)*x2/((x1 - x2)*x1*f2))
                 if (bparab .GT. bparabmax) then
                     isplit = 2*MAX(NINT(0.5*float(nstepmin)/float(ie - ib)), 1)
-                    phi_divide(ib + 1:ie) = isplit
+                    phi_divide(max(1, ib + 1):min(ie, ub_mag)) = isplit
                 end if
             end if
             ib = ie
@@ -5178,7 +5180,7 @@ subroutine rearrange_phideps(ibeg, iend, npart, ncomp, nreal, bcovar_column, &
         ie = iend
         if (ie - ib .LT. nstepmin) then
             isplit = 2*MAX(NINT(0.5*float(nstepmin)/float(ie - ib)), 1)
-            phi_divide(ib + 1:ie) = isplit
+            phi_divide(max(1, ib + 1):min(ie, ub_mag)) = isplit
         end if
     end if
 

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -261,6 +261,9 @@ SUBROUTINE ripple_solver(                                 &
   DOUBLE PRECISION, DIMENSION(3)                :: cp_channel
   INTEGER :: cp_istep,cp_k,cp_trace_status,cp_unit
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: dlogbdphi_mfl
+  DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: unused_dbcovar_mfl
+  DOUBLE PRECISION, DIMENSION(:,:), ALLOCATABLE :: crossing_real
+  COMPLEX(kind=dp), DIMENSION(:,:), ALLOCATABLE :: crossing_complex
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: delt_pos,delt_neg
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: fact_pos_b,fact_neg_b
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: fact_pos_e,fact_neg_e
@@ -269,6 +272,7 @@ SUBROUTINE ripple_solver(                                 &
   !! Modification by Andreas F. Martitsch (28.07.2015)
   !  multi-species part
   INTEGER :: ispec, ispecp, ispecpp ! species indices
+  INTEGER :: crossing_ncomp, crossing_nreal
   INTEGER :: drive_spec
   INTEGER :: isw_regper, ipart1
   DOUBLE PRECISION :: deleta_factor
@@ -769,6 +773,35 @@ PRINT *,'right boundary layer ignored'
     h_phi_mfl(iend-1:iend)=h_phi_mfl(ub_mag)
     dlogbdphi_mfl(iend-1:iend)=dlogbdphi_mfl(ub_mag)
   ENDIF
+
+  subsqmin=1.d5*EPSILON(1.d0)
+  allocate(delt_pos(ibeg:iend),delt_neg(ibeg:iend))
+  allocate(fact_pos_b(ibeg:iend),fact_neg_b(ibeg:iend))
+  allocate(fact_pos_e(ibeg:iend),fact_neg_e(ibeg:iend))
+  allocate(unused_dbcovar_mfl(ibeg:iend))
+  crossing_nreal=1
+  crossing_ncomp=1
+  allocate(crossing_real(ibeg:iend,crossing_nreal))
+  allocate(crossing_complex(ibeg:iend,crossing_ncomp))
+  crossing_real(:,1)=h_phi_mfl
+  crossing_complex(:,1)=cmplx(geodcu_mfl,0.d0,kind=dp)
+  unused_dbcovar_mfl=0.d0
+
+  call rearrange_phideps(ibeg,iend,npart,crossing_ncomp,crossing_nreal,0, &
+       subsqmin,phi_divide,phi_mfl,bhat_mfl,dlogbdphi_mfl,              &
+       unused_dbcovar_mfl,crossing_real,crossing_complex,eta,           &
+       delt_pos,delt_neg,fact_pos_b,fact_neg_b,fact_pos_e,fact_neg_e)
+
+  h_phi_mfl=crossing_real(:,1)
+  geodcu_mfl=real(crossing_complex(:,1),kind=dp)
+  deallocate(crossing_real,crossing_complex,unused_dbcovar_mfl)
+
+  if(maxval(phi_divide).gt.1) then
+    ierr=3
+    write(*,*) 'ERROR: crossing geometry requires phi refinement.'
+    return
+  endif
+
   eta_modboundary_l=1.d0/bhat_mfl(ibeg)
   eta_modboundary_r=1.d0/bhat_mfl(iend)
   ! allocation
@@ -918,26 +951,6 @@ PRINT *,'right boundary layer ignored'
   ALLOCATE(amat(ndim,ndim),bvec_lapack(ndim,ndim),ipivot(ndim))
 
   npart_loc=0
-  subsqmin=1.d5*EPSILON(1.d0)
-
-  allocate(delt_pos(ibeg:iend),delt_neg(ibeg:iend))
-  allocate(fact_pos_b(ibeg:iend),fact_neg_b(ibeg:iend))
-  allocate(fact_pos_e(ibeg:iend),fact_neg_e(ibeg:iend))
-
-  call rearrange_phideps_old(ibeg,iend,npart,subsqmin,phi_divide,    &
-                         phi_mfl,bhat_mfl,geodcu_mfl,h_phi_mfl,eta,  &
-                         delt_pos,delt_neg,                          &
-                         fact_pos_b,fact_neg_b,fact_pos_e,fact_neg_e)
-
-  if(maxval(phi_divide).gt.1) then
-    ierr=3
-    DEALLOCATE(deriv_coef,npl)
-    DEALLOCATE(rhs_mat_lorentz,rhs_mat_energ)
-    DEALLOCATE(q_rip,q_hel_b,q_hel_e)
-    DEALLOCATE(convol_flux,convol_curr)
-    DEALLOCATE(pleg_bra,pleg_ket,scalprod_pleg)
-    return
-  endif
 
   DO istep=ibeg,iend
 

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -787,7 +787,7 @@ PRINT *,'right boundary layer ignored'
   crossing_complex(:,1)=cmplx(geodcu_mfl,0.d0,kind=dp)
   unused_dbcovar_mfl=0.d0
 
-  call rearrange_phideps(ibeg,iend,npart,crossing_ncomp,crossing_nreal,0, &
+  call rearrange_phideps(ibeg,iend,ub_mag,npart,crossing_ncomp,crossing_nreal,0, &
        subsqmin,phi_divide,phi_mfl,bhat_mfl,dlogbdphi_mfl,              &
        unused_dbcovar_mfl,crossing_real,crossing_complex,eta,           &
        delt_pos,delt_neg,fact_pos_b,fact_neg_b,fact_pos_e,fact_neg_e)

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -151,6 +151,19 @@ set_tests_properties(phi_crossing_alignment_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_crossing_geometry_padding test_crossing_geometry_padding.f90)
+target_link_libraries(test_crossing_geometry_padding neo2_ql)
+
+add_test(NAME crossing_geometry_padding_test
+         COMMAND test_crossing_geometry_padding
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(crossing_geometry_padding_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_join_failure_diagnostic test_join_failure_diagnostic.f90)
 target_link_libraries(test_join_failure_diagnostic neo2_ql)
 

--- a/TEST/test_crossing_geometry_padding.f90
+++ b/TEST/test_crossing_geometry_padding.f90
@@ -1,0 +1,168 @@
+program test_crossing_geometry_padding
+    ! Regression for the modify_br = 1 crossing path. rearrange_phideps
+    ! receives the padded array extent iend = ub_mag + 2 while phi_divide
+    ! is allocated (1:ub_mag). The crossing scan must ignore the duplicated
+    ! padding nodes, alignment must match the unpadded result bit for bit,
+    ! and every refinement flag must land inside phi_divide(1:ub_mag) so
+    ! the caller's ierr = 3 gate keeps firing.
+    !
+    ! Profile: phi(i) = 0.05 i on 0:40, bhat = 1 + (phi - 1)^2/2, one pitch
+    ! band at bhat_cross = 1.1. The two simple crossings sit at
+    ! phi = 1 -/+ sqrt(0.2), aligned onto nodes 11 and 29, both more than
+    ! nstepmin nodes away from either edge so no legacy sub-interval split
+    ! can trigger.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use device_mod, only: fieldpropagator
+
+    implicit none
+
+    integer, parameter :: ub_mag = 40, npart = 1
+    real(dp), parameter :: bhat_cross = 1.1_dp
+    real(dp), parameter :: root_tolerance = 1.0e-9_dp
+    real(dp), parameter :: band_tolerance = 1.0e-12_dp
+
+    real(dp) :: phi_ref(0:ub_mag), bhat_ref(0:ub_mag)
+    real(dp) :: phi_out(0:ub_mag), bhat_out(0:ub_mag)
+    real(dp) :: root_left, root_right
+    integer :: divide_ref(1:ub_mag), divide_out(1:ub_mag)
+
+    allocate (fieldpropagator)
+
+    root_left = 1.0_dp - sqrt(0.2_dp)
+    root_right = 1.0_dp + sqrt(0.2_dp)
+
+    ! Control: no padding (modify_br = 0 layout).
+    call run_case(.false., 0.0_dp, .false., phi_ref, bhat_ref, divide_ref)
+    if (maxval(divide_ref) /= 1) &
+        error stop 'FAIL: unpadded case requested refinement'
+    if (abs(bhat_ref(11)/bhat_cross - 1.0_dp) > band_tolerance) &
+        error stop 'FAIL: unpadded left crossing was not aligned'
+    if (abs(bhat_ref(29)/bhat_cross - 1.0_dp) > band_tolerance) &
+        error stop 'FAIL: unpadded right crossing was not aligned'
+    if (abs(phi_ref(11) - root_left) > root_tolerance) &
+        error stop 'FAIL: unpadded left crossing node misses the root'
+    if (abs(phi_ref(29) - root_right) > root_tolerance) &
+        error stop 'FAIL: unpadded right crossing node misses the root'
+
+    ! Padded, boundary field raised above every physical value.
+    call run_case(.true., 1.6_dp, .false., phi_out, bhat_out, divide_out)
+    if (maxval(divide_out) /= 1) &
+        error stop 'FAIL: benign padding triggered spurious refinement'
+    if (any(phi_out /= phi_ref)) &
+        error stop 'FAIL: benign padding changed the aligned coordinates'
+    if (any(bhat_out /= bhat_ref)) &
+        error stop 'FAIL: benign padding changed the aligned field'
+
+    ! Padded, boundary field below the crossing band: the padding nodes
+    ! look like an extra pitch crossing and must still be ignored.
+    call run_case(.true., 1.05_dp, .false., phi_out, bhat_out, divide_out)
+    if (maxval(divide_out) /= 1) &
+        error stop 'FAIL: low padding triggered spurious refinement'
+    if (any(phi_out /= phi_ref)) &
+        error stop 'FAIL: low padding changed the aligned coordinates'
+    if (any(bhat_out /= bhat_ref)) &
+        error stop 'FAIL: low padding changed the aligned field'
+
+    ! Padded, non-monotone physical field: the rejection flag must land
+    ! inside phi_divide(1:ub_mag) so maxval(phi_divide) > 1 in the caller.
+    call run_case(.true., 1.6_dp, .true., phi_out, bhat_out, divide_out)
+    if (divide_out(3) /= 2) &
+        error stop 'FAIL: physical rejection flag missed interval 3'
+    if (sum(divide_out) /= ub_mag + 1) &
+        error stop 'FAIL: physical rejection flagged extra intervals'
+
+    print '(a)', 'All tests passed!'
+
+contains
+
+    subroutine run_case(padded, bhat_pad, bump, phi_physical, bhat_physical, &
+            divide)
+        logical, intent(in) :: padded, bump
+        real(dp), intent(in) :: bhat_pad
+        real(dp), intent(out) :: phi_physical(0:ub_mag)
+        real(dp), intent(out) :: bhat_physical(0:ub_mag)
+        integer, intent(out) :: divide(1:ub_mag)
+
+        interface
+            subroutine rearrange_phideps(ibeg, iend, ub_mag, npart, ncomp, &
+                    nreal, bcovar_column, subsqmin, phi_divide, phi_mfl, &
+                    bhat_mfl, dlogbdphi_mfl, dbcovar_s_hat_dphi_mfl, &
+                    arr_real, arr_comp, eta, delt_pos, delt_neg, &
+                    fact_pos_b, fact_neg_b, fact_pos_e, fact_neg_e)
+                import :: dp
+                integer :: ibeg, iend, npart, ncomp, nreal, bcovar_column
+                integer, intent(in) :: ub_mag
+                real(dp) :: subsqmin
+                integer, dimension(1:ub_mag) :: phi_divide
+                real(dp), dimension(ibeg:iend) :: phi_mfl, bhat_mfl
+                real(dp), dimension(ibeg:iend) :: dlogbdphi_mfl
+                real(dp), dimension(ibeg:iend) :: dbcovar_s_hat_dphi_mfl
+                real(dp), dimension(ibeg:iend, nreal) :: arr_real
+                complex(dp), dimension(ibeg:iend, ncomp) :: arr_comp
+                real(dp), dimension(0:npart) :: eta
+                real(dp), dimension(ibeg:iend) :: delt_pos, delt_neg
+                real(dp), dimension(ibeg:iend) :: fact_pos_b, fact_neg_b
+                real(dp), dimension(ibeg:iend) :: fact_pos_e, fact_neg_e
+            end subroutine rearrange_phideps
+        end interface
+
+        real(dp), allocatable :: phi(:), bhat(:), dlogbdphi(:), dbcovar(:)
+        real(dp), allocatable :: delt_pos(:), delt_neg(:)
+        real(dp), allocatable :: fact_pos_b(:), fact_neg_b(:)
+        real(dp), allocatable :: fact_pos_e(:), fact_neg_e(:)
+        real(dp), allocatable :: arr_real(:, :)
+        complex(dp), allocatable :: arr_comp(:, :)
+        real(dp) :: eta(0:npart), subsqmin
+        integer :: i, iend
+
+        iend = ub_mag
+        if (padded) iend = ub_mag + 2
+
+        allocate (phi(0:iend), bhat(0:iend), dlogbdphi(0:iend))
+        allocate (dbcovar(0:iend), delt_pos(0:iend), delt_neg(0:iend))
+        allocate (fact_pos_b(0:iend), fact_neg_b(0:iend))
+        allocate (fact_pos_e(0:iend), fact_neg_e(0:iend))
+        allocate (arr_real(0:iend, 1), arr_comp(0:iend, 1))
+
+        do i = 0, ub_mag
+            phi(i) = 0.05_dp*real(i, dp)
+            bhat(i) = 1.0_dp + 0.5_dp*(phi(i) - 1.0_dp)**2
+        end do
+        if (bump) bhat(2) = 1.05_dp
+        if (padded) then
+            phi(ub_mag + 1:iend) = phi(ub_mag)
+            bhat(ub_mag + 1:iend) = bhat_pad
+        end if
+        dlogbdphi = (phi - 1.0_dp)/bhat
+        dbcovar = 0.0_dp
+        arr_real(:, 1) = 1.0_dp
+        arr_comp(:, 1) = cmplx(phi, 0.0_dp, dp)
+
+        eta(0) = 0.0_dp
+        eta(1) = 1.0_dp/bhat_cross
+        subsqmin = 1.0e5_dp*epsilon(1.0_dp)
+        divide = 2
+
+        call rearrange_phideps(0, iend, ub_mag, npart, 1, 1, 0, subsqmin, &
+            divide, phi, bhat, dlogbdphi, dbcovar, arr_real, arr_comp, eta, &
+            delt_pos, delt_neg, fact_pos_b, fact_neg_b, fact_pos_e, &
+            fact_neg_e)
+
+        if (padded) then
+            if (any(phi(ub_mag + 1:iend) /= phi(ub_mag))) &
+                error stop 'FAIL: alignment moved a padding coordinate'
+            if (any(bhat(ub_mag + 1:iend) /= bhat_pad)) &
+                error stop 'FAIL: alignment changed a padding field value'
+        end if
+        if (maxval(divide) == 1) then
+            if (any(delt_pos(1:iend) /= phi(1:iend) - phi(0:iend - 1))) &
+                error stop 'FAIL: integration steps mismatch moved nodes'
+            if (any(fact_pos_b(0:iend) /= 1.0_dp)) &
+                error stop 'FAIL: step factors were modified'
+        end if
+
+        phi_physical = phi(0:ub_mag)
+        bhat_physical = bhat(0:ub_mag)
+    end subroutine run_case
+
+end program test_crossing_geometry_padding

--- a/TEST/test_phi_crossing_alignment.f90
+++ b/TEST/test_phi_crossing_alignment.f90
@@ -1,12 +1,19 @@
 program test_phi_crossing_alignment
     use, intrinsic :: iso_fortran_env, only: real64
-    use phi_crossing_alignment_mod, only: nearest_phi_crossing_offset
+    use phi_crossing_alignment_mod, only: bracketed_phi_crossing, &
+        claim_crossing_target, crossing_no_bracket, crossing_non_simple, &
+        crossing_ok, nearest_phi_crossing_offset
 
     implicit none
 
     real(real64), parameter :: eta_cross = 1.0076495897856284_real64
+    real(real64), parameter :: tolerance = 1.0e-12_real64
     real(real64) :: bhat(-1:1)
-    integer :: offset
+    real(real64) :: bhat_profile(0:7), derivative_weights(6)
+    real(real64) :: phi_cross, phi_profile(0:7), weights(6)
+    real(real64) :: eta_root
+    logical :: claimed(0:7)
+    integer :: offset, status, stencil_left, target
 
     bhat = [0.99203602638228305_real64, 0.99274003698367863_real64, &
         0.99340_real64]
@@ -31,6 +38,53 @@ program test_phi_crossing_alignment
     offset = nearest_phi_crossing_offset(bhat, eta_cross)
     if (offset /= 1) &
         error stop 'FAIL: nearest neighbor was not selected'
+
+    phi_profile = [(real(offset, real64), offset = 0, 7)]
+    bhat_profile = 1.0_real64 + 0.2_real64*phi_profile
+    eta_root = 1.0_real64/(1.0_real64 + 0.2_real64*2.3_real64)
+    call bracketed_phi_crossing(0, 7, phi_profile, bhat_profile, 2, &
+        eta_root, phi_cross, stencil_left, weights, derivative_weights, &
+        target, status)
+    if (status /= crossing_ok) error stop 'FAIL: linear root was rejected'
+    if (abs(phi_cross - 2.3_real64) > tolerance) &
+        error stop 'FAIL: linear root was not recovered'
+    if (target /= 2) error stop 'FAIL: nearest bracket node was not selected'
+    if (abs(sum(weights) - 1.0_real64) > tolerance) &
+        error stop 'FAIL: interpolation does not preserve constants'
+    if (abs(sum(weights*bhat_profile(stencil_left:stencil_left + 5)) &
+        *eta_root - 1.0_real64) > tolerance) &
+        error stop 'FAIL: interpolated field misses the pitch boundary'
+    if (abs(sum(derivative_weights* &
+        bhat_profile(stencil_left:stencil_left + 5)) - 0.2_real64) &
+        > tolerance) &
+        error stop 'FAIL: field derivative is inconsistent'
+
+    eta_root = 1.0_real64/(1.0_real64 + 0.2_real64*0.1_real64)
+    call bracketed_phi_crossing(0, 7, phi_profile, bhat_profile, 0, &
+        eta_root, phi_cross, stencil_left, weights, derivative_weights, &
+        target, status)
+    if (status /= crossing_ok .or. target /= 1) &
+        error stop 'FAIL: periodic endpoint was selected for movement'
+
+    eta_root = 1.0_real64/4.0_real64
+    call bracketed_phi_crossing(0, 7, phi_profile, bhat_profile, 2, &
+        eta_root, phi_cross, stencil_left, weights, derivative_weights, &
+        target, status)
+    if (status /= crossing_no_bracket) &
+        error stop 'FAIL: missing bracket was not rejected'
+
+    bhat_profile = 1.0_real64 + (phi_profile - 2.5_real64)**3
+    call bracketed_phi_crossing(0, 7, phi_profile, bhat_profile, 2, &
+        1.0_real64, phi_cross, stencil_left, weights, derivative_weights, &
+        target, status)
+    if (status /= crossing_non_simple) &
+        error stop 'FAIL: non-simple root was not rejected'
+
+    claimed = .false.
+    if (.not. claim_crossing_target(claimed, 3)) &
+        error stop 'FAIL: first crossing claim was rejected'
+    if (claim_crossing_target(claimed, 3)) &
+        error stop 'FAIL: competing crossing claim was accepted'
 
     print '(a)', 'All tests passed!'
 end program test_phi_crossing_alignment


### PR DESCRIPTION
## Problem

PR 164 makes the discrete constant-distribution null exact, but its crossing
repair changes only `bhat_mfl` at a grid point. The coordinate, metric, drift,
and derivative arrays remain sampled at the old point. This creates an
internally inconsistent geometry that moves with spatial resolution.

## Change

- Locate each simple trapped-passing boundary from the bracketed root
  `1 - eta B(phi) = 0` in the existing six-point Lagrange representation.
- Move the nearer interior node to the root without changing the node count,
  pitch bands, array bounds, ABI, or serialized propagator layout.
- Interpolate `B`, `h_phi`, `dlogB/ds`, `bcovar_s_hat`, and `geodcu` from one
  unchanged stencil. Recompute `dlogB/dphi` and `d(bcovar_s_hat)/dphi` from
  the same polynomial.
- Apply the same path to the Arnoldi and axisymmetric QL solvers. Derived NTV
  arrays and nonuniform cell factors are built after alignment.
- Request spatial refinement when the bracket is lost, the root is not simple,
  one cell crosses more than one pitch band, the field is not monotone away
  from its minimum, or two crossings require the same node.

The magnetic-field representation, CGS units, pitch measure, mirror and
periodic endpoint conventions, node order, and solver storage layout are
unchanged. This PR changes where existing field data are sampled; it does not
change the collision operator or introduce a new source.

This PR is stacked on #164 and should remain unmerged until the pinned spatial
and pitch campaigns pass.

## Verification

### Test fails on the base branch

With the new behavioral test applied before the implementation:

```text
$ fo test phi_crossing_alignment_test
TEST/test_phi_crossing_alignment.f90: Function 'claim_crossing_target' has no IMPLICIT type
Summary: build failed
```

### Test passes after fix

```text
$ fo test phi_crossing_alignment_test
phi_crossing_alignment_test                PASS       0.06s
Summary: 1 passed, 0 failed, 0 skipped (  0.06s)
```

```text
$ fo
Static: OK (356 modules, 356 changed, 356 affected)
Build: OK
Tests: OK
Lint: OK
Fmt: WARN
All stages passed (.7s)
```

The format warning is limited to the two pre-existing legacy solver files;
the module and behavioral test are formatted.
