### PR TITLE
Retain per-level diagnostics for closure attribution

### DIFF
--- a/NEO-2-QL/CMakeSources.in
+++ b/NEO-2-QL/CMakeSources.in
@@ -12,6 +12,7 @@ set(NEO2_QL_SRC_FILES
   ripple_solver_ArnoldiOrder2_test.f90
   join_diagnostics_mod.f90
   lorentz_projection_diagnostics_mod.f90
+  stage2_attribution_mod.f90
   join_ripples_int.f90
   join_ripples.f90
   join_ends.f90

--- a/NEO-2-QL/CMakeSources.in
+++ b/NEO-2-QL/CMakeSources.in
@@ -13,6 +13,7 @@ set(NEO2_QL_SRC_FILES
   join_diagnostics_mod.f90
   lorentz_projection_diagnostics_mod.f90
   stage2_attribution_mod.f90
+  peak_rss_mod.f90
   join_ripples_int.f90
   join_ripples.f90
   join_ends.f90

--- a/NEO-2-QL/join_diagnostics_mod.f90
+++ b/NEO-2-QL/join_diagnostics_mod.f90
@@ -128,14 +128,24 @@ contains
         join_end_trace_enabled = allocated(join_end_output_filename)
     end function join_end_trace_enabled
 
+    !> Append one periodic-join compatibility record to the join-end trace.
+    !>
+    !> delta_eta_l/delta_eta_r are the per-band pitch measures of the joined
+    !> propagator boundaries used by the Lorentz solvability correction in
+    !> join_ends.f90; they are empty when that correction is inactive.  The
+    !> emitted source_correction_m/source_correction_p rows are the per-band,
+    !> per-force products delta_eta_l*facnorm and delta_eta_r*facnorm that
+    !> join_ends subtracts from source_m and source_p, so the periodic-closure
+    !> projection footprint is reconstructible band by band.
     subroutine record_join_end_compatibility(source_factor, source_before, &
-            source_after, source_scale, measure_sum, compatibility, &
-            dropped_p, dropped_m, &
+            source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+            compatibility, dropped_p, dropped_m, &
             compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
             right_null, left_residual, right_residual, left_scale, right_scale, &
             transfer_error, ierr)
         real(real64), intent(in) :: source_factor(3), source_before(3)
         real(real64), intent(in) :: source_after(3), source_scale(3), measure_sum
+        real(real64), intent(in) :: delta_eta_l(:), delta_eta_r(:)
         real(real64), intent(in) :: compatibility(:, :), dropped_p(:, :)
         real(real64), intent(in) :: dropped_m(:, :), left_null(:, :)
         real(real64), intent(in) :: compatibility_scale(:, :)
@@ -145,7 +155,7 @@ contains
         real(real64), intent(in) :: right_scale(:), transfer_error(2)
         integer, intent(out) :: ierr
 
-        integer :: force, index, iunit, laguerre, status
+        integer :: band, force, index, iunit, laguerre, status
 
         ierr = 0
         if (.not. join_end_trace_enabled(ierr)) return
@@ -170,6 +180,8 @@ contains
             .or. .not. all(ieee_is_finite(source_after)) &
             .or. .not. all(ieee_is_finite(source_scale)) &
             .or. .not. ieee_is_finite(measure_sum) &
+            .or. .not. all(ieee_is_finite(delta_eta_l)) &
+            .or. .not. all(ieee_is_finite(delta_eta_r)) &
             .or. .not. all(ieee_is_finite(compatibility)) &
             .or. .not. all(ieee_is_finite(dropped_p)) &
             .or. .not. all(ieee_is_finite(dropped_m)) &
@@ -212,6 +224,24 @@ contains
                 source_after(force), status)
             call write_join_end_value(iunit, 'source_scale', -1, force, -1, &
                 source_scale(force), status)
+        end do
+        do band = 1, size(delta_eta_l)
+            call write_join_end_value(iunit, 'delta_eta_l', -1, 0, band, &
+                delta_eta_l(band), status)
+            do force = 1, 3
+                call write_join_end_value(iunit, 'source_correction_m', -1, &
+                    force, band, delta_eta_l(band)*source_factor(force), &
+                    status)
+            end do
+        end do
+        do band = 1, size(delta_eta_r)
+            call write_join_end_value(iunit, 'delta_eta_r', -1, 0, band, &
+                delta_eta_r(band), status)
+            do force = 1, 3
+                call write_join_end_value(iunit, 'source_correction_p', -1, &
+                    force, band, delta_eta_r(band)*source_factor(force), &
+                    status)
+            end do
         end do
         call write_join_end_value(iunit, 'measure_sum', -1, 0, -1, &
             measure_sum, status)

--- a/NEO-2-QL/join_ends.f90
+++ b/NEO-2-QL/join_ends.f90
@@ -455,8 +455,13 @@ CLOSE(752)
           +ABS(periodic_rhs(nts_l+(m+1)*nr,i)),TINY(1.d0))
       ENDDO
     ENDDO
+    ! The delta_eta arrays exist only when the Lorentz solvability
+    ! correction ran; export empty band vectors otherwise.
+    IF(.NOT.ALLOCATED(delta_eta_l)) ALLOCATE(delta_eta_l(0))
+    IF(.NOT.ALLOCATED(delta_eta_r)) ALLOCATE(delta_eta_r(0))
     CALL record_join_end_compatibility(source_factor,source_before, &
-         source_after,source_scale,measure_sum,compatibility,dropped_p, &
+         source_after,source_scale,measure_sum,delta_eta_l,delta_eta_r, &
+         compatibility,dropped_p, &
          dropped_m,compatibility_scale,dropped_p_scale,dropped_m_scale, &
          left_null,right_null,left_residual,right_residual,left_scale, &
          right_scale,transfer_error,ierr)

--- a/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
+++ b/NEO-2-QL/lorentz_projection_diagnostics_mod.f90
@@ -18,6 +18,13 @@ module lorentz_projection_diagnostics_mod
         real(real64) :: intertwining_scale
     end type local_projection_residuals
 
+    !> Distinct code for diagnostic-output I/O failures.  This must never be
+    !> 3: callers in ripple_solver_axi_test.f90 forward these codes as the
+    !> solver ierr, and propagator.f90 interprets ierr=3 as a retryable
+    !> phi-refinement request, so an I/O failure reported as 3 would trigger
+    !> pointless refinement retries instead of a hard stop.
+    integer, parameter, public :: local_projection_io_error = 13
+
     character(len=:), allocatable, save :: output_filename
     integer, save :: record_sequence = 0
     logical, save :: output_initialized = .false.
@@ -259,7 +266,7 @@ contains
         open(newunit=iunit, file=output_filename, status='old', position='append', &
             action='write', iostat=status)
         if (status /= 0) then
-            ierr = 3
+            ierr = local_projection_io_error
             return
         end if
         do force = 1, 3
@@ -277,7 +284,7 @@ contains
         call write_value(iunit, tag, 'measure', -1, residuals%measure, &
             max(abs(residuals%measure), tiny(1.0_real64)), status)
         close(iunit, iostat=ierr)
-        if (status /= 0 .or. ierr /= 0) ierr = 3
+        if (status /= 0 .or. ierr /= 0) ierr = local_projection_io_error
     end subroutine record_local_projection_residuals
 
     subroutine record_local_constant_stage_residuals(tag, sparse_residual, &
@@ -296,7 +303,7 @@ contains
         open(newunit=iunit, file=output_filename, status='old', position='append', &
             action='write', iostat=status)
         if (status /= 0) then
-            ierr = 3
+            ierr = local_projection_io_error
             return
         end if
         call write_value(iunit, tag, 'sparse_constant', sparse_index, &
@@ -312,7 +319,7 @@ contains
         call write_value(iunit, tag, 'sparse_band', sparse_band, &
             sparse_residual, sparse_scale, status)
         close(iunit, iostat=ierr)
-        if (status /= 0 .or. ierr /= 0) ierr = 3
+        if (status /= 0 .or. ierr /= 0) ierr = local_projection_io_error
     end subroutine record_local_constant_stage_residuals
 
     subroutine record_local_constant_row(tag, row, irow, icol, values, state, &
@@ -364,7 +371,7 @@ contains
             if (status /= 0) exit
         end do
         close(iunit, iostat=ierr)
-        if (status /= 0 .or. ierr /= 0) ierr = 3
+        if (status /= 0 .or. ierr /= 0) ierr = local_projection_io_error
     end subroutine record_local_constant_row
 
     subroutine decode_state_index(index, npl, ind_start, ibeg, iend, lag, &
@@ -437,7 +444,7 @@ contains
                 'sequence,propagator,kind,index,value,scale'
             close(iunit, iostat=ierr)
         end if
-        if (status /= 0 .or. ierr /= 0) ierr = 3
+        if (status /= 0 .or. ierr /= 0) ierr = local_projection_io_error
         if (ierr /= 0 .and. allocated(output_filename)) deallocate(output_filename)
     end subroutine initialize_output
 end module lorentz_projection_diagnostics_mod

--- a/NEO-2-QL/neo2.f90
+++ b/NEO-2-QL/neo2.f90
@@ -7,6 +7,7 @@ module neo2_ql
   USE hdf5_tools
   use system_utility, only : get_rusage
   use rusage_type, only : fortran_rusage, write_fortran_rusage
+  use peak_rss_mod, only : record_peak_rss
 
   USE size_mod
   USE flint_mod, ONLY : plot_gauss,plot_prop,phi_split_mode,        &
@@ -188,6 +189,7 @@ module neo2_ql
   REAL(kind=dp), DIMENSION(:), ALLOCATABLE :: dn_vec_ov_ds
 
   type(fortran_rusage) :: usage
+  INTEGER :: ierr_peak_rss
 
   !! End Modification by Andreas F. Martitsch (23.08.2015)
   ! groups for namelist
@@ -479,6 +481,12 @@ subroutine main
   if (mpro%isMaster()) then
     usage = get_rusage()
     call write_fortran_rusage(usage)
+    ! Opt-in per-process peak-RSS accounting (NEO2_PEAK_RSS_FILE).
+    call record_peak_rss(mpro%getRank(), ierr_peak_rss)
+    if (ierr_peak_rss .ne. 0) then
+      print *, 'WARNING: peak RSS accounting was not written, code ', &
+           ierr_peak_rss
+    end if
   end if
 
   !*******************************************

--- a/NEO-2-QL/peak_rss_mod.f90
+++ b/NEO-2-QL/peak_rss_mod.f90
@@ -1,0 +1,78 @@
+module peak_rss_mod
+    !> Per-process peak resident-set-size accounting.
+    !>
+    !> current_peak_rss_kib reads VmHWM (the resident-set high-water mark of
+    !> the calling process, in KiB) from /proc/self/status.  record_peak_rss
+    !> writes it to the CSV file named by NEO2_PEAK_RSS_FILE, following the
+    !> opt-in NEO2_*_FILE pattern of qflux_profile_mod; with the variable
+    !> unset nothing is written.  The value is per process: under MPI each
+    !> rank sees its own high-water mark, and the caller decides which ranks
+    !> report.
+    use, intrinsic :: iso_fortran_env, only: int64
+    implicit none
+    private
+
+    public :: current_peak_rss_kib, record_peak_rss
+
+contains
+
+    subroutine current_peak_rss_kib(peak_kib, ierr)
+        integer(int64), intent(out) :: peak_kib
+        integer, intent(out) :: ierr
+
+        character(len=256) :: line
+        character(len=8) :: unit_token
+        integer :: iunit, status
+
+        peak_kib = -1_int64
+        ierr = 1
+        open(newunit=iunit, file='/proc/self/status', status='old', &
+            action='read', iostat=status)
+        if (status /= 0) return
+        do
+            read(iunit, '(a)', iostat=status) line
+            if (status /= 0) exit
+            if (line(1:6) /= 'VmHWM:') cycle
+            read(line(7:), *, iostat=status) peak_kib, unit_token
+            if (status == 0 .and. trim(unit_token) == 'kB' &
+                .and. peak_kib > 0_int64) ierr = 0
+            exit
+        end do
+        close(iunit)
+        if (ierr /= 0) peak_kib = -1_int64
+    end subroutine current_peak_rss_kib
+
+    subroutine record_peak_rss(rank, ierr)
+        integer, intent(in) :: rank
+        integer, intent(out) :: ierr
+
+        character(len=:), allocatable :: filename
+        integer(int64) :: peak_kib
+        integer :: iunit, length, status
+
+        ierr = 0
+        call get_environment_variable('NEO2_PEAK_RSS_FILE', length=length, &
+            status=status)
+        if (status /= 0 .or. length == 0) return
+        allocate(character(len=length) :: filename)
+        call get_environment_variable('NEO2_PEAK_RSS_FILE', value=filename, &
+            status=status)
+        if (status /= 0) then
+            ierr = 2
+            return
+        end if
+        call current_peak_rss_kib(peak_kib, ierr)
+        if (ierr /= 0) return
+        open(newunit=iunit, file=filename, status='replace', action='write', &
+            iostat=status)
+        if (status /= 0) then
+            ierr = 2
+            return
+        end if
+        write(iunit, '(a)', iostat=status) 'rank,peak_rss_kib'
+        if (status == 0) write(iunit, '(i0,",",i0)', iostat=status) rank, &
+            peak_kib
+        close(iunit, iostat=ierr)
+        if (status /= 0 .or. ierr /= 0) ierr = 2
+    end subroutine record_peak_rss
+end module peak_rss_mod

--- a/NEO-2-QL/propagator.f90
+++ b/NEO-2-QL/propagator.f90
@@ -1310,6 +1310,12 @@ CONTAINS
              CALL modify_propagator(phi_split_mode,phi_place_mode,phi_split_min, &
                   UBOUND(prop_c%p%eta_l,1),prop_c%p%eta_l,mult_solv,count_solv)
              phi_split_mode = phi_split_mode_ori
+             ! One parseable detail line per adaptive recovery; the wording
+             ! must stay clear of the campaign failure and recovery markers.
+             WRITE (*,'(a,i0,a,i0,a,es13.6,a,i0)') &
+                  'reduce_hphi recovery: tag=',fieldpropagator%tag, &
+                  ' count_solv=',count_solv,' mult_solv=',mult_solv, &
+                  ' points=',UBOUND(fieldpropagator%coords%x2,1)+1
              PRINT *, 'Error in ripple_solver: ',ierr_solv
              PRINT *, ' I try it again ',count_solv+1
           ELSE IF (ierr_solv .EQ. 3 .AND. count_solv .GE. max_solver_try) THEN

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -101,6 +101,8 @@ SUBROUTINE ripple_solver(                                 &
        assemble_local_constant_state, compute_sparse_constant_residual, &
        local_projection_trace_enabled, record_local_constant_row, &
        record_local_constant_stage_residuals
+  USE stage2_attribution_mod, ONLY : stage2_attribution_enabled, &
+       apply_stage2_attribution
   !! End Modification by Andreas F. Martitsch (28.07.2015)
 
   IMPLICIT NONE
@@ -238,6 +240,8 @@ SUBROUTINE ripple_solver(                                 &
   COMPLEX(kind=dp), DIMENSION(:,:), ALLOCATABLE :: q_hel_b,q_hel_e
   COMPLEX(kind=dp) :: amp_hel_b,amp_hel_e,hel_phase,hel_phase_fac
   LOGICAL :: hel_drive_active,trace_constant_state
+  LOGICAL :: attribution_active
+  INTEGER :: attribution_ierr
   DOUBLE PRECISION :: constant_sparse_residual,constant_sparse_scale
   DOUBLE PRECISION :: constant_solve_residual,constant_solve_scale
   INTEGER :: constant_sparse_index,constant_solve_index,constant_trace_ierr
@@ -1695,6 +1699,25 @@ PRINT *,'right boundary layer ignored'
     IF(iplot.EQ.1.AND.isw_axisymm.NE.1) &
       CALL apply_reconstructed_incoming_rows(source_vector,flux_pl,flux_mr, &
         ibeg,iend,lag,npl,ind_start)
+  ENDIF
+
+! Stage-2 attribution experiment: subtract the stage-0 periodic-closure
+! projection footprint from the assembled right-hand side before the solve.
+! Guarded by NEO2_STAGE2_ATTRIBUTION_FILE; runs without it are unchanged.
+  IF(iplot.EQ.1) THEN
+    CALL stage2_attribution_enabled(attribution_active,attribution_ierr)
+    IF(attribution_ierr.NE.0) THEN
+      ierr=attribution_ierr
+      RETURN
+    ENDIF
+    IF(attribution_active) THEN
+      CALL apply_stage2_attribution(fieldpropagator%tag,source_vector, &
+        npl,ind_start,ibeg,iend,lag,attribution_ierr)
+      IF(attribution_ierr.NE.0) THEN
+        ierr=attribution_ierr
+        RETURN
+      ENDIF
+    ENDIF
   ENDIF
 
 

--- a/NEO-2-QL/stage2_attribution_mod.f90
+++ b/NEO-2-QL/stage2_attribution_mod.f90
@@ -1,0 +1,256 @@
+module stage2_attribution_mod
+    !> Env-guarded stage-2 attribution experiment for the periodic-closure
+    !> interface jump.
+    !>
+    !> When NEO2_STAGE2_ATTRIBUTION_FILE names a footprint file, the stage-2
+    !> local re-solve subtracts the listed per-band source corrections from
+    !> the assembled right-hand side before sparse_solve.  The footprint rows
+    !> are the source_correction_p/source_correction_m values exported by the
+    !> stage-0 join-end trace (join_diagnostics_mod): the per-band, per-force
+    !> Lorentz solvability corrections delta_eta*facnorm that join_ends
+    !> subtracts from the joined boundary sources.  The band vectors are
+    !> mapped onto the local propagator phase-space grid, matching the
+    !> source_p/source_m extraction order of ripple_solver_axi_test.f90:
+    !>
+    !>   side p: co-passing block at the last spatial step,
+    !>           row = ind_start(iend) + band,          band = 1..npl(iend)+1
+    !>   side m: counter-passing block at the first spatial step,
+    !>           row = ind_start(ibeg) + 2*(npl(ibeg)+1) + 1 - band,
+    !>                                                   band = 1..npl(ibeg)+1
+    !>
+    !> Only lag = 0 (Lorentz) states are accepted, matching the scope of the
+    !> join_ends correction.  This mode measures the remainder of the jump:
+    !> it does not assume the footprint identity holds.  The subtracted rows
+    !> are appended to <file>.applied so the experiment records exactly what
+    !> was removed; the remaining jump is measured by the unchanged interface
+    !> diagnostics downstream.
+    !>
+    !> File format: one header line, then CSV rows
+    !>   tag,side,force,band,value
+    !> with side one of p|m, force in 1..3, and band 1-based.  With the
+    !> environment variable unset this module leaves the solve untouched.
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use, intrinsic :: iso_fortran_env, only: real64
+    implicit none
+    private
+
+    !> Distinct hard-failure codes: never 3, which propagator.f90 treats as
+    !> a retryable phi-refinement request.
+    integer, parameter, public :: stage2_attribution_input_error = 11
+    integer, parameter, public :: stage2_attribution_apply_error = 12
+
+    character(len=:), allocatable, save :: footprint_filename
+    integer, allocatable, save :: row_tag(:), row_force(:), row_band(:)
+    character(len=1), allocatable, save :: row_side(:)
+    real(real64), allocatable, save :: row_value(:)
+    logical, save :: footprint_initialized = .false.
+    logical, save :: applied_output_initialized = .false.
+
+    public :: stage2_attribution_enabled, apply_stage2_attribution
+
+contains
+
+    subroutine stage2_attribution_enabled(enabled, ierr)
+        logical, intent(out) :: enabled
+        integer, intent(out) :: ierr
+
+        ierr = 0
+        if (.not. footprint_initialized) call initialize_footprint(ierr)
+        enabled = ierr == 0 .and. allocated(footprint_filename)
+    end subroutine stage2_attribution_enabled
+
+    !> Subtract the footprint rows recorded for this propagator tag from the
+    !> assembled right-hand side.  Rows for other tags are ignored; a tag
+    !> without rows leaves the solve untouched.
+    subroutine apply_stage2_attribution(tag, rhs, npl, ind_start, ibeg, iend, &
+            lag, ierr)
+        integer, intent(in) :: tag
+        real(real64), intent(inout) :: rhs(:, :)
+        integer, intent(in) :: npl(ibeg:), ind_start(ibeg:)
+        integer, intent(in) :: ibeg, iend, lag
+        integer, intent(out) :: ierr
+
+        integer :: applied_m, applied_p, entry, iunit, row, status
+        real(real64) :: l1_m, l1_p
+
+        ierr = 0
+        if (.not. allocated(footprint_filename)) return
+        if (size(row_tag) == 0) return
+        if (all(row_tag /= tag)) return
+        if (lag /= 0 .or. ibeg > iend .or. size(rhs, 2) /= 3) then
+            write (*, '(a,i0)') &
+                'stage2 attribution: unsupported state layout for tag=', tag
+            ierr = stage2_attribution_apply_error
+            return
+        end if
+
+        call initialize_applied_output(status)
+        if (status /= 0) then
+            ierr = stage2_attribution_input_error
+            return
+        end if
+        open(newunit=iunit, file=footprint_filename//'.applied', &
+            status='old', position='append', action='write', iostat=status)
+        if (status /= 0) then
+            ierr = stage2_attribution_input_error
+            return
+        end if
+
+        applied_p = 0
+        applied_m = 0
+        l1_p = 0.0_real64
+        l1_m = 0.0_real64
+        do entry = 1, size(row_tag)
+            if (row_tag(entry) /= tag) cycle
+            if (row_side(entry) == 'p') then
+                if (row_band(entry) > npl(iend) + 1) then
+                    call report_band_mismatch(tag, entry, npl(iend) + 1)
+                    ierr = stage2_attribution_apply_error
+                    exit
+                end if
+                row = ind_start(iend) + row_band(entry)
+                applied_p = applied_p + 1
+                l1_p = l1_p + abs(row_value(entry))
+            else
+                if (row_band(entry) > npl(ibeg) + 1) then
+                    call report_band_mismatch(tag, entry, npl(ibeg) + 1)
+                    ierr = stage2_attribution_apply_error
+                    exit
+                end if
+                row = ind_start(ibeg) + 2*(npl(ibeg) + 1) + 1 - row_band(entry)
+                applied_m = applied_m + 1
+                l1_m = l1_m + abs(row_value(entry))
+            end if
+            if (row < 1 .or. row > size(rhs, 1)) then
+                call report_band_mismatch(tag, entry, size(rhs, 1))
+                ierr = stage2_attribution_apply_error
+                exit
+            end if
+            rhs(row, row_force(entry)) = rhs(row, row_force(entry)) &
+                - row_value(entry)
+            write(iunit, '(i0,",",a,",",3(i0,","),es25.16e3)', iostat=status) &
+                tag, row_side(entry), row_force(entry), row_band(entry), row, &
+                row_value(entry)
+            if (status /= 0) then
+                ierr = stage2_attribution_input_error
+                exit
+            end if
+        end do
+        close(iunit, iostat=status)
+        if (ierr == 0 .and. status /= 0) ierr = stage2_attribution_input_error
+        if (ierr /= 0) return
+        write (*, '(a,i0,a,i0,a,es13.6,a,i0,a,es13.6)') &
+            'stage2 attribution: tag=', tag, ' rows_p=', applied_p, &
+            ' l1_p=', l1_p, ' rows_m=', applied_m, ' l1_m=', l1_m
+    end subroutine apply_stage2_attribution
+
+    subroutine report_band_mismatch(tag, entry, bound)
+        integer, intent(in) :: tag, entry, bound
+
+        write (*, '(3(a,i0),a,i0)') &
+            'stage2 attribution: band outside local grid for tag=', tag, &
+            ' entry=', entry, ' band=', row_band(entry), ' bound=', bound
+    end subroutine report_band_mismatch
+
+    subroutine initialize_footprint(ierr)
+        integer, intent(out) :: ierr
+
+        character(len=1024) :: line
+        character(len=1) :: side
+        integer :: band, force, iunit, length, n_rows, status, tag
+        real(real64) :: value
+
+        ierr = 0
+        footprint_initialized = .true.
+        call get_environment_variable('NEO2_STAGE2_ATTRIBUTION_FILE', &
+            length=length, status=status)
+        if (status /= 0 .or. length == 0) return
+        allocate(character(len=length) :: footprint_filename)
+        call get_environment_variable('NEO2_STAGE2_ATTRIBUTION_FILE', &
+            value=footprint_filename, status=status)
+        if (status == 0) then
+            open(newunit=iunit, file=footprint_filename, status='old', &
+                action='read', iostat=status)
+        end if
+        if (status /= 0) then
+            call reject_footprint(0)
+            ierr = stage2_attribution_input_error
+            return
+        end if
+        read(iunit, '(a)', iostat=status) line
+        if (status /= 0) then
+            close(iunit)
+            call reject_footprint(1)
+            ierr = stage2_attribution_input_error
+            return
+        end if
+        n_rows = 0
+        do
+            read(iunit, '(a)', iostat=status) line
+            if (status /= 0) exit
+            if (len_trim(line) == 0) cycle
+            n_rows = n_rows + 1
+        end do
+        allocate(row_tag(n_rows), row_side(n_rows), row_force(n_rows))
+        allocate(row_band(n_rows), row_value(n_rows))
+        rewind(iunit)
+        read(iunit, '(a)', iostat=status) line
+        n_rows = 0
+        do
+            read(iunit, '(a)', iostat=status) line
+            if (status < 0) exit
+            if (status > 0) then
+                close(iunit)
+                call reject_footprint(n_rows + 2)
+                ierr = stage2_attribution_input_error
+                return
+            end if
+            if (len_trim(line) == 0) cycle
+            read(line, *, iostat=status) tag, side, force, band, value
+            if (status /= 0 .or. (side /= 'p' .and. side /= 'm') &
+                .or. force < 1 .or. force > 3 .or. band < 1 &
+                .or. .not. ieee_is_finite(value)) then
+                close(iunit)
+                call reject_footprint(n_rows + 2)
+                ierr = stage2_attribution_input_error
+                return
+            end if
+            n_rows = n_rows + 1
+            row_tag(n_rows) = tag
+            row_side(n_rows) = side
+            row_force(n_rows) = force
+            row_band(n_rows) = band
+            row_value(n_rows) = value
+        end do
+        close(iunit)
+    end subroutine initialize_footprint
+
+    subroutine reject_footprint(line_number)
+        integer, intent(in) :: line_number
+
+        write (*, '(a,a,a,i0)') 'stage2 attribution: footprint file ', &
+            'rejected, line ', 'number=', line_number
+        if (allocated(footprint_filename)) deallocate(footprint_filename)
+        if (allocated(row_tag)) deallocate(row_tag)
+        if (allocated(row_side)) deallocate(row_side)
+        if (allocated(row_force)) deallocate(row_force)
+        if (allocated(row_band)) deallocate(row_band)
+        if (allocated(row_value)) deallocate(row_value)
+    end subroutine reject_footprint
+
+    subroutine initialize_applied_output(status)
+        integer, intent(out) :: status
+
+        integer :: iunit
+
+        status = 0
+        if (applied_output_initialized) return
+        open(newunit=iunit, file=footprint_filename//'.applied', &
+            status='replace', action='write', iostat=status)
+        if (status == 0) then
+            write(iunit, '(a)', iostat=status) 'tag,side,force,band,row,value'
+            close(iunit)
+        end if
+        if (status == 0) applied_output_initialized = .true.
+    end subroutine initialize_applied_output
+end module stage2_attribution_mod

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -193,6 +193,20 @@ set_tests_properties(lorentz_projection_diagnostic_test PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_stage2_attribution test_stage2_attribution.f90)
+target_link_libraries(test_stage2_attribution neo2_ql)
+
+add_test(NAME stage2_attribution_test
+         COMMAND test_stage2_attribution
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(stage2_attribution_test PROPERTIES
+    ENVIRONMENT "NEO2_STAGE2_ATTRIBUTION_FILE=${CMAKE_CURRENT_BINARY_DIR}/stage2_attribution_footprint.csv"
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_qflux_interface_diagnostic test_qflux_interface_diagnostic.f90)
 target_link_libraries(test_qflux_interface_diagnostic neo2_ql)
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -286,6 +286,20 @@ set_tests_properties(qflux_profile PROPERTIES
     TIMEOUT 30
 )
 
+add_executable(test_peak_rss test_peak_rss.f90)
+target_link_libraries(test_peak_rss neo2_ql)
+
+add_test(NAME peak_rss_test
+         COMMAND test_peak_rss
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(peak_rss_test PROPERTIES
+    ENVIRONMENT "NEO2_PEAK_RSS_FILE=${CMAKE_CURRENT_BINARY_DIR}/peak_rss.csv"
+    PASS_REGULAR_EXPRESSION "All tests passed!"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+    TIMEOUT 30
+)
+
 add_executable(test_ntv_output_geometry test_ntv_output_geometry.f90)
 target_link_libraries(test_ntv_output_geometry neo2_ql)
 

--- a/TEST/test_join_failure_diagnostic.f90
+++ b/TEST/test_join_failure_diagnostic.f90
@@ -8,6 +8,7 @@ program test_join_failure_diagnostic
 
     real(kind(1.0d0)) :: bad_dropped(2, 3), compatibility(1, 3)
     real(kind(1.0d0)) :: compatibility_scale(1, 3)
+    real(kind(1.0d0)) :: delta_eta_l(2), delta_eta_r(2)
     real(kind(1.0d0)) :: dropped_m(1, 3), dropped_p(1, 3), factor
     real(kind(1.0d0)) :: dropped_m_scale(1, 3), dropped_p_scale(1, 3)
     real(kind(1.0d0)) :: left_null(2, 1), left_residual(1), left_scale(1)
@@ -22,7 +23,8 @@ program test_join_failure_diagnostic
     character(len=1) :: direction
     integer :: column, force, index, info, ierr, iunit, join, laguerre, line_count
     integer :: new_tags(2), old_tags(2), npass(2), pivot(2), sequence, status
-    logical :: found_right_null, found_source_factor
+    logical :: found_correction_p, found_delta_eta_l, found_right_null
+    logical :: found_source_factor
 
     matrix = reshape([1.0d0, 2.0d0, 2.0d0, 4.0d0], shape(matrix))
     rhs(:, 1) = [1.0d0, 2.0d0]
@@ -61,6 +63,8 @@ program test_join_failure_diagnostic
     source_after = [0.0d0, 0.0d0, 0.0d0]
     source_scale = [25.0d0, 26.0d0, 27.0d0]
     measure_sum = 2.0d0
+    delta_eta_l = [0.5d0, 1.5d0]
+    delta_eta_r = [2.5d0, 3.5d0]
     compatibility = reshape([7.0d0, 8.0d0, 9.0d0], [1, 3])
     dropped_p = reshape([10.0d0, 11.0d0, 12.0d0], [1, 3])
     dropped_m = reshape([13.0d0, 14.0d0, 15.0d0], [1, 3])
@@ -75,8 +79,8 @@ program test_join_failure_diagnostic
     right_scale = [24.0d0]
     transfer_error = [18.0d0, 19.0d0]
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, compatibility, dropped_p, &
-        dropped_m, &
+        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        compatibility, dropped_p, dropped_m, &
         compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
         right_null, left_residual, right_residual, left_scale, right_scale, &
         transfer_error, ierr)
@@ -84,8 +88,8 @@ program test_join_failure_diagnostic
 
     bad_dropped = 0.0d0
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, compatibility, bad_dropped, &
-        dropped_m, &
+        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        compatibility, bad_dropped, dropped_m, &
         compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
         right_null, left_residual, right_residual, left_scale, right_scale, &
         transfer_error, ierr)
@@ -93,12 +97,23 @@ program test_join_failure_diagnostic
 
     source_scale(1) = ieee_value(0.0d0, ieee_quiet_nan)
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, compatibility, dropped_p, &
+        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        compatibility, dropped_p, &
         dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
         left_null, right_null, left_residual, right_residual, left_scale, &
         right_scale, transfer_error, ierr)
     if (ierr /= 7) error stop 'FAIL: non-finite join-end value was accepted'
     source_scale(1) = 25.0d0
+
+    delta_eta_r(2) = ieee_value(0.0d0, ieee_quiet_nan)
+    call record_join_end_compatibility(source_factor, source_before, &
+        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        compatibility, dropped_p, &
+        dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
+        left_null, right_null, left_residual, right_residual, left_scale, &
+        right_scale, transfer_error, ierr)
+    if (ierr /= 7) error stop 'FAIL: non-finite band correction was accepted'
+    delta_eta_r(2) = 3.5d0
 
     call get_environment_variable('NEO2_JOIN_END_TRACE_FILE', filename)
     open(newunit=iunit, file=trim(filename), status='old', action='read', &
@@ -109,6 +124,8 @@ program test_join_failure_diagnostic
         'sequence,join,kind,laguerre,force,index,value') &
         error stop 'FAIL: join-end trace header is wrong'
     line_count = 0
+    found_correction_p = .false.
+    found_delta_eta_l = .false.
     found_right_null = .false.
     found_source_factor = .false.
     do
@@ -126,9 +143,18 @@ program test_join_failure_diagnostic
         if (trim(record_kind) == 'right_null' .and. index == 2) then
             found_right_null = value == 4.0d0
         end if
+        if (trim(record_kind) == 'delta_eta_l' .and. index == 2) then
+            found_delta_eta_l = value == 1.5d0
+        end if
+        if (trim(record_kind) == 'source_correction_p' .and. force == 2 &
+            .and. index == 1) then
+            ! delta_eta_r(1)*source_factor(2) = 2.5*2.0
+            found_correction_p = value == 5.0d0
+        end if
     end do
     close(iunit)
-    if (line_count /= 44 .or. .not. found_source_factor &
-        .or. .not. found_right_null) &
+    if (line_count /= 60 .or. .not. found_source_factor &
+        .or. .not. found_right_null .or. .not. found_delta_eta_l &
+        .or. .not. found_correction_p) &
         error stop 'FAIL: join-end trace content is wrong'
 end program test_join_failure_diagnostic

--- a/TEST/test_peak_rss.f90
+++ b/TEST/test_peak_rss.f90
@@ -1,0 +1,42 @@
+program test_peak_rss
+    use, intrinsic :: iso_fortran_env, only: int64
+    use peak_rss_mod, only: current_peak_rss_kib, record_peak_rss
+    implicit none
+
+    real(kind(1.0d0)), allocatable :: ballast(:)
+    character(len=1024) :: filename
+    character(len=64) :: header
+    integer(int64) :: peak_after, peak_before, recorded
+    integer :: ierr, iunit, rank, status
+
+    call current_peak_rss_kib(peak_before, ierr)
+    if (ierr /= 0 .or. peak_before <= 0_int64) &
+        error stop 'FAIL: VmHWM was not read from /proc/self/status'
+
+    ! Touch 64 MiB so the high-water mark provably moves.
+    allocate(ballast(8*1024*1024))
+    call random_number(ballast)
+    call current_peak_rss_kib(peak_after, ierr)
+    if (ierr /= 0) error stop 'FAIL: VmHWM was not re-read'
+    if (peak_after < peak_before + 32768_int64) &
+        error stop 'FAIL: peak RSS did not track the 64 MiB allocation'
+    if (ballast(1) < 0.0d0) error stop 'FAIL: ballast values are invalid'
+
+    call record_peak_rss(3, ierr)
+    if (ierr /= 0) error stop 'FAIL: peak RSS record was not written'
+
+    call get_environment_variable('NEO2_PEAK_RSS_FILE', filename)
+    open(newunit=iunit, file=trim(filename), status='old', action='read', &
+        iostat=status)
+    if (status /= 0) error stop 'FAIL: peak RSS output is absent'
+    read(iunit, '(a)', iostat=status) header
+    if (status /= 0 .or. trim(header) /= 'rank,peak_rss_kib') &
+        error stop 'FAIL: peak RSS header is wrong'
+    read(iunit, *, iostat=status) rank, recorded
+    close(iunit)
+    if (status /= 0 .or. rank /= 3) error stop 'FAIL: peak RSS record is wrong'
+    if (recorded < peak_after) &
+        error stop 'FAIL: recorded peak is below the observed peak'
+
+    write(*, '(a)') 'All tests passed!'
+end program test_peak_rss

--- a/TEST/test_stage2_attribution.f90
+++ b/TEST/test_stage2_attribution.f90
@@ -1,0 +1,96 @@
+program test_stage2_attribution
+    use, intrinsic :: iso_fortran_env, only: real64
+    use stage2_attribution_mod, only: apply_stage2_attribution, &
+        stage2_attribution_apply_error, stage2_attribution_enabled
+    implicit none
+
+    character(len=1024) :: filename
+    character(len=64) :: header
+    character(len=1) :: side
+    real(real64) :: rhs(14, 3), value
+    integer :: band, force, ierr, ind_start(3), iunit, npl(3), row, status, tag
+    integer :: line_count
+    logical :: enabled
+
+    ! The footprint file is written before the module reads it lazily.
+    call get_environment_variable('NEO2_STAGE2_ATTRIBUTION_FILE', filename)
+    if (len_trim(filename) == 0) &
+        error stop 'FAIL: NEO2_STAGE2_ATTRIBUTION_FILE is not set'
+    open(newunit=iunit, file=trim(filename), status='replace', action='write')
+    write(iunit, '(a)') 'tag,side,force,band,value'
+    write(iunit, '(a)') '7,p,1,1,0.25'
+    write(iunit, '(a)') '7,p,1,2,0.5'
+    write(iunit, '(a)') '7,m,2,1,0.125'
+    write(iunit, '(a)') '7,m,2,2,0.0625'
+    write(iunit, '(a)') '9,p,3,1,1.0'
+    write(iunit, '(a)') '9,m,1,5,0.5'
+    close(iunit)
+
+    call stage2_attribution_enabled(enabled, ierr)
+    if (ierr /= 0 .or. .not. enabled) &
+        error stop 'FAIL: valid footprint file was not accepted'
+
+    ! Local grid: three spatial steps, npl = [1, 2, 1], lag = 0, so the
+    ! per-step block sizes are [4, 6, 4] and ind_start = [0, 4, 10].
+    npl = [1, 2, 1]
+    ind_start = [0, 4, 10]
+
+    ! A tag without footprint rows must leave the solve untouched.
+    rhs = 1.0_real64
+    call apply_stage2_attribution(5, rhs, npl, ind_start, 1, 3, 0, ierr)
+    if (ierr /= 0 .or. any(rhs /= 1.0_real64)) &
+        error stop 'FAIL: tag without rows modified the right-hand side'
+
+    call apply_stage2_attribution(7, rhs, npl, ind_start, 1, 3, 0, ierr)
+    if (ierr /= 0) error stop 'FAIL: valid footprint application failed'
+    ! side p, band b: row = ind_start(iend) + b
+    if (rhs(11, 1) /= 0.75_real64 .or. rhs(12, 1) /= 0.5_real64) &
+        error stop 'FAIL: co-passing correction landed on the wrong rows'
+    ! side m, band b: row = ind_start(ibeg) + 2*(npl(ibeg)+1) + 1 - b
+    if (rhs(4, 2) /= 0.875_real64 .or. rhs(3, 2) /= 0.9375_real64) &
+        error stop 'FAIL: counter-passing correction landed on the wrong rows'
+    rhs(11, 1) = 1.0_real64
+    rhs(12, 1) = 1.0_real64
+    rhs(4, 2) = 1.0_real64
+    rhs(3, 2) = 1.0_real64
+    if (any(rhs /= 1.0_real64)) &
+        error stop 'FAIL: correction touched rows outside the footprint'
+
+    ! Non-Lorentz state layouts are outside the join_ends correction scope.
+    rhs = 1.0_real64
+    call apply_stage2_attribution(7, rhs, npl, ind_start, 1, 3, 1, ierr)
+    if (ierr /= stage2_attribution_apply_error) &
+        error stop 'FAIL: lag > 0 state was accepted'
+
+    ! A band beyond the local boundary grid must be a hard failure.
+    rhs = 1.0_real64
+    call apply_stage2_attribution(9, rhs, npl, ind_start, 1, 3, 0, ierr)
+    if (ierr /= stage2_attribution_apply_error) &
+        error stop 'FAIL: band outside the local grid was accepted'
+
+    ! The applied trace records exactly what was subtracted.
+    open(newunit=iunit, file=trim(filename)//'.applied', status='old', &
+        action='read', iostat=status)
+    if (status /= 0) error stop 'FAIL: applied trace is absent'
+    read(iunit, '(a)', iostat=status) header
+    if (status /= 0 .or. trim(header) /= 'tag,side,force,band,row,value') &
+        error stop 'FAIL: applied trace header is wrong'
+    line_count = 0
+    do
+        read(iunit, *, iostat=status) tag, side, force, band, row, value
+        if (status < 0) exit
+        if (status > 0) error stop 'FAIL: malformed applied trace row'
+        line_count = line_count + 1
+        if (line_count == 1) then
+            if (tag /= 7 .or. side /= 'p' .or. force /= 1 .or. band /= 1 &
+                .or. row /= 11 .or. value /= 0.25_real64) &
+                error stop 'FAIL: applied trace record is wrong'
+        end if
+    end do
+    close(iunit)
+    ! Four rows from the accepted tag-7 application plus the valid tag-9
+    ! co-passing row written before its counter-passing band was rejected.
+    if (line_count /= 5) error stop 'FAIL: applied trace row count differs'
+
+    write(*, '(a)') 'All tests passed!'
+end program test_stage2_attribution


### PR DESCRIPTION
## Problem

The rejected PR 165 campaigns localized the 8.05e-4/7.61e-4 interface jump to
the periodic-closure pair and attributed it to the Lorentz solvability
projection that `join_ends` applies only to the final joined propagator, while
the stage-2 local re-solves use unprojected sources. That attribution is
plausible but unproven (2.6-3.1% magnitude mismatch), and the recorded runs
left three observability gaps: the projection footprint was not reconstructible
per band, adaptive pitch recoveries were only countable rather than
attributable, and the 20.5 GiB campaign peak RSS had no per-process source.
Separately, `lorentz_projection_diagnostics_mod` reported trace I/O failures as
ierr=3, which `propagator.f90` treats as a retryable phi-refinement request.

## Change

- Export the per-band, per-force corrections `delta_eta_l/r * facnorm` that
  `join_ends` subtracts from `source_m`/`source_p`, as additive kinds
  `delta_eta_l`, `delta_eta_r`, `source_correction_m`, `source_correction_p`
  in the existing join-end trace CSV schema.
- Add the discriminator experiment for the closure jump: when
  `NEO2_STAGE2_ATTRIBUTION_FILE` names a footprint file (rows
  `tag,side,force,band,value` taken from the stage-0 export above), the
  stage-2 re-solve subtracts those band vectors from the **assembled**
  right-hand side before `sparse_solve`, mapped onto the local propagator
  phase-space grid (side p: `ind_start(iend)+band`; side m:
  `ind_start(ibeg)+2*(npl(ibeg)+1)+1-band`), not taken from the post-solve
  `source_vector_all`. Applied rows go to `<file>.applied`; the remaining
  jump stays a measured quantity downstream — the footprint identity is not
  assumed.
- Add `peak_rss_mod`: per-process VmHWM from `/proc/self/status`, written to
  `NEO2_PEAK_RSS_FILE` following the `NEO2_*_FILE` pattern of
  `qflux_profile_mod`, hooked at end of run in `neo2.f90`.
- Report projection-trace I/O failures as the distinct public code
  `local_projection_io_error = 13` instead of the retryable ierr=3.
- Emit one parseable detail line per `reduce_hphi` recovery: propagator tag,
  `count_solv`, halved `mult_solv`, resulting phi point count.

All new stdout lines were checked against the campaign failure regex
(`run_reconstruction.py:17-21`) and the `Error in ripple_solver:` recovery
marker (line 22); none match, so failure detection and recovery counting are
unchanged.

## Preserved invariants

- With `NEO2_STAGE2_ATTRIBUTION_FILE` and `NEO2_PEAK_RSS_FILE` unset, solver
  behavior and outputs are bit-identical; runs without recoveries print no new
  lines.
- The join-end trace header and existing record kinds are unchanged; the new
  kinds are additive.
- CGS units, Fourier convention, discretizations, tolerances, ABI, and the
  serialized propagator layout are unchanged.

## Driver-side companion (flux_pumping repo)

- `run_reconstruction.py` `JOIN_END_TRACE_KINDS` must admit the four new kinds
  before `FLUX_PUMPING_JOIN_END_TRACE=1` runs against this head.
- The attribution campaign builds the footprint file from the stage-0
  `source_correction_p/m` rows for the closure-pair tags and sets
  `NEO2_STAGE2_ATTRIBUTION_FILE` for stage 2 only.

## Verification

Touched tests on this head:

```text
join_failure_diagnostic_test               PASS       0.06s
stage2_attribution_test                    PASS       0.06s
peak_rss_test                              PASS       0.11s
lorentz_projection_diagnostic_test         PASS       0.06s
propagator_io_test                         PASS       0.06s
phi_crossing_alignment_test                PASS       0.06s
crossing_geometry_padding_test             PASS       0.06s
qflux_interface_diagnostic_test            PASS       0.06s
```

Full suite comparison against the base head 6aec6fc (same worktree, same
toolchain): base `fo test --all` gives 28 passed / 16 failed, this head gives
30 passed / the identical 16 failures (pre-existing environmental
collision-operator and multispecies test failures, untouched by this PR; the
+2 are the new behavioral tests).

```text
$ fo
Build: OK
Tests: OK
Lint: OK
All stages passed (16.3s)
```

This PR is stacked on #165 (base `fix/flux-pumping/preserve-crossing-geometry`,
now including the crossing-scan bounds fix) and should remain unmerged until
owner review of the stack.
