### PR TITLE
Trace the flux-side closure correction and gate the Lorentz correction

### DIFF
--- a/NEO-2-QL/join_diagnostics_mod.f90
+++ b/NEO-2-QL/join_diagnostics_mod.f90
@@ -11,11 +11,41 @@ module join_diagnostics_mod
     integer, save :: join_end_sequence = 0
     logical, save :: normalization_output_initialized = .false.
     logical, save :: join_end_output_initialized = .false.
+    logical, save :: correction_switch_initialized = .false.
+    logical, save :: correction_switch_disabled = .false.
 
-    public :: join_end_trace_enabled, record_join_end_compatibility
+    public :: join_end_trace_enabled, join_lorentz_correction_disabled
+    public :: record_join_end_compatibility
     public :: report_join_failure, validate_join_normalization
 
 contains
+
+    !> True when NEO2_DISABLE_JOIN_LORENTZ_CORRECTION=1 requests the
+    !> controlled A/B experiment: the periodic join then keeps the
+    !> uncorrected sources and extraction rows while the trace still
+    !> records the would-be correction factors.  The audit line below is
+    !> the loud marker a runner must require before trusting a disabled
+    !> run (mirror of the stage-2 attribution marker).
+    logical function join_lorentz_correction_disabled()
+        character(len=1) :: flag
+        integer :: length, status
+
+        if (.not. correction_switch_initialized) then
+            correction_switch_initialized = .true.
+            ! .and. does not short-circuit; flag must be defined even when
+            ! the variable is absent and the intrinsic leaves it alone.
+            flag = '0'
+            call get_environment_variable( &
+                'NEO2_DISABLE_JOIN_LORENTZ_CORRECTION', value=flag, &
+                length=length, status=status)
+            correction_switch_disabled = status == 0 .and. length == 1 &
+                .and. flag == '1'
+            if (correction_switch_disabled) write(*, '(a)') &
+                'join_ends: Lorentz solvability correction disabled by ' // &
+                'NEO2_DISABLE_JOIN_LORENTZ_CORRECTION'
+        end if
+        join_lorentz_correction_disabled = correction_switch_disabled
+    end function join_lorentz_correction_disabled
 
     subroutine report_join_failure(stage, info, old_tags, new_tags, ndim, ndim1, &
             matrix, rhs, ierr)
@@ -137,14 +167,28 @@ contains
     !> per-force products delta_eta_l*facnorm and delta_eta_r*facnorm that
     !> join_ends subtracts from source_m and source_p, so the periodic-closure
     !> projection footprint is reconstructible band by band.
+    !>
+    !> flux_factor is the per-force scalar that join_ends subtracts
+    !> uniformly from both flux extraction rows; flux_before/flux_after are
+    !> the measure-weighted extraction sums around that subtraction and
+    !> flux_scale their absolute-value counterpart.  The emitted
+    !> flux_correction_m/flux_correction_p rows repeat flux_factor per band
+    !> so the flux-side footprint has the same row format as the source
+    !> side.  Flux rows never enter the periodic solution (join_ripples
+    !> composes them only into qflux and other flux rows), so this channel
+    !> can shift extracted transport coefficients but not the pointwise
+    !> reconstruction.
     subroutine record_join_end_compatibility(source_factor, source_before, &
-            source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+            source_after, source_scale, flux_factor, flux_before, &
+            flux_after, flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
             compatibility, dropped_p, dropped_m, &
             compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
             right_null, left_residual, right_residual, left_scale, right_scale, &
             transfer_error, ierr)
         real(real64), intent(in) :: source_factor(3), source_before(3)
         real(real64), intent(in) :: source_after(3), source_scale(3), measure_sum
+        real(real64), intent(in) :: flux_factor(3), flux_before(3)
+        real(real64), intent(in) :: flux_after(3), flux_scale(3)
         real(real64), intent(in) :: delta_eta_l(:), delta_eta_r(:)
         real(real64), intent(in) :: compatibility(:, :), dropped_p(:, :)
         real(real64), intent(in) :: dropped_m(:, :), left_null(:, :)
@@ -179,6 +223,10 @@ contains
             .or. .not. all(ieee_is_finite(source_before)) &
             .or. .not. all(ieee_is_finite(source_after)) &
             .or. .not. all(ieee_is_finite(source_scale)) &
+            .or. .not. all(ieee_is_finite(flux_factor)) &
+            .or. .not. all(ieee_is_finite(flux_before)) &
+            .or. .not. all(ieee_is_finite(flux_after)) &
+            .or. .not. all(ieee_is_finite(flux_scale)) &
             .or. .not. ieee_is_finite(measure_sum) &
             .or. .not. all(ieee_is_finite(delta_eta_l)) &
             .or. .not. all(ieee_is_finite(delta_eta_r)) &
@@ -203,7 +251,8 @@ contains
             .or. any(dropped_m_scale <= 0.0_real64) &
             .or. any(left_scale <= 0.0_real64) &
             .or. any(right_scale <= 0.0_real64) &
-            .or. any(source_scale <= 0.0_real64)) then
+            .or. any(source_scale <= 0.0_real64) &
+            .or. any(flux_scale <= 0.0_real64)) then
             ierr = 7
             return
         end if
@@ -224,6 +273,14 @@ contains
                 source_after(force), status)
             call write_join_end_value(iunit, 'source_scale', -1, force, -1, &
                 source_scale(force), status)
+            call write_join_end_value(iunit, 'flux_factor', -1, force, -1, &
+                flux_factor(force), status)
+            call write_join_end_value(iunit, 'flux_before', -1, force, -1, &
+                flux_before(force), status)
+            call write_join_end_value(iunit, 'flux_after', -1, force, -1, &
+                flux_after(force), status)
+            call write_join_end_value(iunit, 'flux_scale', -1, force, -1, &
+                flux_scale(force), status)
         end do
         do band = 1, size(delta_eta_l)
             call write_join_end_value(iunit, 'delta_eta_l', -1, 0, band, &
@@ -232,6 +289,8 @@ contains
                 call write_join_end_value(iunit, 'source_correction_m', -1, &
                     force, band, delta_eta_l(band)*source_factor(force), &
                     status)
+                call write_join_end_value(iunit, 'flux_correction_m', -1, &
+                    force, band, flux_factor(force), status)
             end do
         end do
         do band = 1, size(delta_eta_r)
@@ -241,6 +300,8 @@ contains
                 call write_join_end_value(iunit, 'source_correction_p', -1, &
                     force, band, delta_eta_r(band)*source_factor(force), &
                     status)
+                call write_join_end_value(iunit, 'flux_correction_p', -1, &
+                    force, band, flux_factor(force), status)
             end do
         end do
         call write_join_end_value(iunit, 'measure_sum', -1, 0, -1, &

--- a/NEO-2-QL/join_ends.f90
+++ b/NEO-2-QL/join_ends.f90
@@ -24,6 +24,7 @@ SUBROUTINE join_ends(ierr)
   USE lapack_band
   USE collisionality_mod, ONLY : isw_lorentz
   USE join_diagnostics_mod, ONLY : join_end_trace_enabled, &
+                                   join_lorentz_correction_disabled, &
                                    record_join_end_compatibility
 
   IMPLICIT NONE
@@ -76,7 +77,9 @@ SUBROUTINE join_ends(ierr)
   DOUBLE PRECISION :: facnorm
   DOUBLE PRECISION :: measure_sum,source_after(3),source_before(3)
   DOUBLE PRECISION :: source_factor(3),source_scale(3),transfer_error(2)
-  LOGICAL :: trace_join_end
+  DOUBLE PRECISION :: flux_after(3),flux_before(3),flux_factor(3)
+  DOUBLE PRECISION :: flux_scale(3)
+  LOGICAL :: correction_disabled,trace_join_end
 
   ! initialize
   ierr = 0
@@ -120,6 +123,10 @@ PRINT *,'nl,nr = ',nl,nr
                 +SUM(ABS(o%p%source_m),DIM=1)
     source_scale=MAX(source_scale,TINY(1.d0))
     source_after=source_before
+    flux_factor=0.d0
+    flux_before=0.d0
+    flux_after=0.d0
+    flux_scale=TINY(1.d0)
     measure_sum=0.d0
     transfer_error=0.d0
     DO idiag=1,SIZE(c_forward,1)
@@ -161,19 +168,39 @@ PRINT *,'nl,nr = ',nl,nr
 
     IF(trace_join_end) measure_sum=SUM(delta_eta_l)+SUM(delta_eta_r)
 
+    ! Controlled A/B experiment: with the correction disabled the periodic
+    ! solve keeps the uncorrected sources and extraction rows while the
+    ! trace still records the would-be correction factors.
+    correction_disabled = join_lorentz_correction_disabled()
+
     DO i=1,3
 
       facnorm=(SUM(o%p%source_p(:,i))+SUM(o%p%source_m(:,i)))          &
              *0.5d0/o%p%eta_boundary_r
       IF(trace_join_end) source_factor(i)=facnorm
-      o%p%source_p(:,i)=o%p%source_p(:,i)-delta_eta_r*facnorm
-      o%p%source_m(:,i)=o%p%source_m(:,i)-delta_eta_l*facnorm
+      IF(.NOT.correction_disabled) THEN
+        o%p%source_p(:,i)=o%p%source_p(:,i)-delta_eta_r*facnorm
+        o%p%source_m(:,i)=o%p%source_m(:,i)-delta_eta_l*facnorm
+      ENDIF
 
       facnorm=(SUM(o%p%flux_p(i,:)*delta_eta_l)                        &
              +SUM(o%p%flux_m(i,:)*delta_eta_r))                        &
              *0.5d0/o%p%eta_boundary_r
-      o%p%flux_p(i,:)=o%p%flux_p(i,:)-facnorm
-      o%p%flux_m(i,:)=o%p%flux_m(i,:)-facnorm
+      IF(trace_join_end) THEN
+        flux_factor(i)=facnorm
+        flux_before(i)=SUM(o%p%flux_p(i,:)*delta_eta_l)               &
+                      +SUM(o%p%flux_m(i,:)*delta_eta_r)
+        flux_scale(i)=MAX(SUM(ABS(o%p%flux_p(i,:))*delta_eta_l)       &
+                         +SUM(ABS(o%p%flux_m(i,:))*delta_eta_r),      &
+                          TINY(1.d0))
+      ENDIF
+      IF(.NOT.correction_disabled) THEN
+        o%p%flux_p(i,:)=o%p%flux_p(i,:)-facnorm
+        o%p%flux_m(i,:)=o%p%flux_m(i,:)-facnorm
+      ENDIF
+      IF(trace_join_end)                                               &
+        flux_after(i)=SUM(o%p%flux_p(i,:)*delta_eta_l)                &
+                     +SUM(o%p%flux_m(i,:)*delta_eta_r)
 
     ENDDO
 
@@ -460,7 +487,8 @@ CLOSE(752)
     IF(.NOT.ALLOCATED(delta_eta_l)) ALLOCATE(delta_eta_l(0))
     IF(.NOT.ALLOCATED(delta_eta_r)) ALLOCATE(delta_eta_r(0))
     CALL record_join_end_compatibility(source_factor,source_before, &
-         source_after,source_scale,measure_sum,delta_eta_l,delta_eta_r, &
+         source_after,source_scale,flux_factor,flux_before,flux_after, &
+         flux_scale,measure_sum,delta_eta_l,delta_eta_r, &
          compatibility,dropped_p, &
          dropped_m,compatibility_scale,dropped_p_scale,dropped_m_scale, &
          left_null,right_null,left_residual,right_residual,left_scale, &

--- a/NEO-2-QL/qflux_profile_mod.f90
+++ b/NEO-2-QL/qflux_profile_mod.f90
@@ -120,6 +120,7 @@ contains
         character(len=5) :: side
         integer :: band, base, column, endpoint, force, iunit, m, nband, point
         integer :: status
+        real(dp) :: constant_coordinate(3), source_solution_orthogonal
 
         ierr = 0
         if (.not. interface_trace_initialized) call initialize_interface_trace(ierr)
@@ -169,26 +170,50 @@ contains
                 side = 'right'
             end if
             nband = block_npassing(point) + 1
+            base = block_base(point)
+            ! The Lorentz collision operator's discrete right-null state is
+            ! one constant shared by the co- and counter-passing lag=0 rows.
+            ! Export the Euclidean-orthogonal component as a diagnostic; the
+            ! raw solution and all solver inputs remain unchanged.
+            do force = 1, 3
+                constant_coordinate(force) = sum( &
+                    source_solution(base + 1:base + nband, force))
+                constant_coordinate(force) = constant_coordinate(force) + sum( &
+                    source_solution(base + nband + 1:base + 2*nband, force))
+            end do
+            constant_coordinate = constant_coordinate/real(2*nband, dp)
             do m = 0, lag
                 base = block_base(point) + 2*m*nband
                 do band = 1, nband
                     column = base + band
                     do force = 1, 3
+                        source_solution_orthogonal = &
+                            source_solution(column, force)
+                        if (m == 0) source_solution_orthogonal = &
+                            source_solution_orthogonal - &
+                            constant_coordinate(force)
                         call write_interface_trace(iunit, tag, side, 'p', m, &
                             force, band - 1, eta_grid(band - 1), phi(point), &
                             flux_row(column)/step_plus(point), &
                             source_rhs(column, force), &
-                            source_solution(column, force), status)
+                            source_solution(column, force), &
+                            source_solution_orthogonal, status)
                         if (status /= 0) exit
                     end do
                     if (status /= 0) exit
                     column = base + 2*nband - band + 1
                     do force = 1, 3
+                        source_solution_orthogonal = &
+                            source_solution(column, force)
+                        if (m == 0) source_solution_orthogonal = &
+                            source_solution_orthogonal - &
+                            constant_coordinate(force)
                         call write_interface_trace(iunit, tag, side, 'm', m, &
                             force, band - 1, eta_grid(band - 1), phi(point), &
                             flux_row(column)/step_minus(point), &
                             source_rhs(column, force), &
-                            source_solution(column, force), status)
+                            source_solution(column, force), &
+                            source_solution_orthogonal, status)
                         if (status /= 0) exit
                     end do
                     if (status /= 0) exit
@@ -203,18 +228,19 @@ contains
 
     subroutine write_interface_trace(iunit, tag, side, direction, laguerre, &
             force, eta_index, eta_value, phi, flux_kernel, source_rhs, &
-            source_solution, status)
+            source_solution, source_solution_orthogonal, status)
         integer, intent(in) :: iunit, tag, laguerre, force, eta_index
         character(len=*), intent(in) :: side, direction
         real(dp), intent(in) :: eta_value, phi, flux_kernel, source_rhs
-        real(dp), intent(in) :: source_solution
+        real(dp), intent(in) :: source_solution, source_solution_orthogonal
         integer, intent(out) :: status
 
         interface_trace_sequence = interface_trace_sequence + 1
-        write(iunit, '(2(i0,","),a,",",a,",",3(i0,","),4(es25.16e3,","),' // &
+        write(iunit, '(2(i0,","),a,",",a,",",3(i0,","),5(es25.16e3,","),' // &
             'es25.16e3)', iostat=status) interface_trace_sequence, tag, &
             trim(side), direction, laguerre, force, eta_index, eta_value, phi, &
-            flux_kernel, source_rhs, source_solution
+            flux_kernel, source_rhs, source_solution, &
+            source_solution_orthogonal
     end subroutine write_interface_trace
 
     subroutine initialize_interface_trace(ierr)
@@ -236,7 +262,8 @@ contains
         if (status == 0) then
             write(iunit, '(a)', iostat=status) &
                 'sequence,tag,side,direction,laguerre,force,eta_index,eta,phi,' // &
-                'flux_kernel,source_rhs,source_solution'
+                'flux_kernel,source_rhs,source_solution,' // &
+                'source_solution_orthogonal'
             close(iunit, iostat=ierr)
         end if
         if (status /= 0) ierr = status

--- a/TEST/test_join_failure_diagnostic.f90
+++ b/TEST/test_join_failure_diagnostic.f90
@@ -1,6 +1,7 @@
 program test_join_failure_diagnostic
     use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
-    use join_diagnostics_mod, only: record_join_end_compatibility, &
+    use join_diagnostics_mod, only: join_lorentz_correction_disabled, &
+        record_join_end_compatibility, &
         report_join_failure, &
         validate_join_normalization
     use lapack_band, only: gbsv
@@ -16,6 +17,8 @@ program test_join_failure_diagnostic
     real(kind(1.0d0)) :: right_null(2, 1), right_residual(1), right_scale(1)
     real(kind(1.0d0)) :: source_after(3), source_before(3)
     real(kind(1.0d0)) :: source_factor(3), source_scale(3), transfer_error(2)
+    real(kind(1.0d0)) :: flux_after(3), flux_before(3), flux_factor(3)
+    real(kind(1.0d0)) :: flux_scale(3)
     real(kind(1.0d0)) :: value
     character(len=1024) :: filename
     character(len=128) :: header
@@ -24,6 +27,7 @@ program test_join_failure_diagnostic
     integer :: column, force, index, info, ierr, iunit, join, laguerre, line_count
     integer :: new_tags(2), old_tags(2), npass(2), pivot(2), sequence, status
     logical :: found_correction_p, found_delta_eta_l, found_right_null
+    logical :: found_flux_correction_m, found_flux_factor
     logical :: found_source_factor
 
     matrix = reshape([1.0d0, 2.0d0, 2.0d0, 4.0d0], shape(matrix))
@@ -58,10 +62,17 @@ program test_join_failure_diagnostic
         .or. factor /= 1.0d0) &
         error stop 'FAIL: join normalization record is wrong'
 
+    if (join_lorentz_correction_disabled()) &
+        error stop 'FAIL: correction reported disabled without the env switch'
+
     source_factor = [1.0d0, 2.0d0, 3.0d0]
     source_before = [4.0d0, 5.0d0, 6.0d0]
     source_after = [0.0d0, 0.0d0, 0.0d0]
     source_scale = [25.0d0, 26.0d0, 27.0d0]
+    flux_factor = [30.0d0, 31.0d0, 32.0d0]
+    flux_before = [33.0d0, 34.0d0, 35.0d0]
+    flux_after = [0.0d0, 0.0d0, 0.0d0]
+    flux_scale = [36.0d0, 37.0d0, 38.0d0]
     measure_sum = 2.0d0
     delta_eta_l = [0.5d0, 1.5d0]
     delta_eta_r = [2.5d0, 3.5d0]
@@ -79,7 +90,8 @@ program test_join_failure_diagnostic
     right_scale = [24.0d0]
     transfer_error = [18.0d0, 19.0d0]
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        source_after, source_scale, flux_factor, flux_before, flux_after, &
+        flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
         compatibility, dropped_p, dropped_m, &
         compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
         right_null, left_residual, right_residual, left_scale, right_scale, &
@@ -88,7 +100,8 @@ program test_join_failure_diagnostic
 
     bad_dropped = 0.0d0
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        source_after, source_scale, flux_factor, flux_before, flux_after, &
+        flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
         compatibility, bad_dropped, dropped_m, &
         compatibility_scale, dropped_p_scale, dropped_m_scale, left_null, &
         right_null, left_residual, right_residual, left_scale, right_scale, &
@@ -97,7 +110,8 @@ program test_join_failure_diagnostic
 
     source_scale(1) = ieee_value(0.0d0, ieee_quiet_nan)
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        source_after, source_scale, flux_factor, flux_before, flux_after, &
+        flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
         compatibility, dropped_p, &
         dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
         left_null, right_null, left_residual, right_residual, left_scale, &
@@ -107,13 +121,25 @@ program test_join_failure_diagnostic
 
     delta_eta_r(2) = ieee_value(0.0d0, ieee_quiet_nan)
     call record_join_end_compatibility(source_factor, source_before, &
-        source_after, source_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        source_after, source_scale, flux_factor, flux_before, flux_after, &
+        flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
         compatibility, dropped_p, &
         dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
         left_null, right_null, left_residual, right_residual, left_scale, &
         right_scale, transfer_error, ierr)
     if (ierr /= 7) error stop 'FAIL: non-finite band correction was accepted'
     delta_eta_r(2) = 3.5d0
+
+    flux_scale(1) = ieee_value(0.0d0, ieee_quiet_nan)
+    call record_join_end_compatibility(source_factor, source_before, &
+        source_after, source_scale, flux_factor, flux_before, flux_after, &
+        flux_scale, measure_sum, delta_eta_l, delta_eta_r, &
+        compatibility, dropped_p, &
+        dropped_m, compatibility_scale, dropped_p_scale, dropped_m_scale, &
+        left_null, right_null, left_residual, right_residual, left_scale, &
+        right_scale, transfer_error, ierr)
+    if (ierr /= 7) error stop 'FAIL: non-finite flux scale was accepted'
+    flux_scale(1) = 36.0d0
 
     call get_environment_variable('NEO2_JOIN_END_TRACE_FILE', filename)
     open(newunit=iunit, file=trim(filename), status='old', action='read', &
@@ -126,6 +152,8 @@ program test_join_failure_diagnostic
     line_count = 0
     found_correction_p = .false.
     found_delta_eta_l = .false.
+    found_flux_correction_m = .false.
+    found_flux_factor = .false.
     found_right_null = .false.
     found_source_factor = .false.
     do
@@ -151,10 +179,19 @@ program test_join_failure_diagnostic
             ! delta_eta_r(1)*source_factor(2) = 2.5*2.0
             found_correction_p = value == 5.0d0
         end if
+        if (trim(record_kind) == 'flux_factor' .and. force == 2) then
+            found_flux_factor = value == 31.0d0
+        end if
+        if (trim(record_kind) == 'flux_correction_m' .and. force == 2 &
+            .and. index == 1) then
+            ! the flux correction is the uniform per-force scalar
+            found_flux_correction_m = value == 31.0d0
+        end if
     end do
     close(iunit)
-    if (line_count /= 60 .or. .not. found_source_factor &
+    if (line_count /= 84 .or. .not. found_source_factor &
         .or. .not. found_right_null .or. .not. found_delta_eta_l &
-        .or. .not. found_correction_p) &
+        .or. .not. found_correction_p .or. .not. found_flux_factor &
+        .or. .not. found_flux_correction_m) &
         error stop 'FAIL: join-end trace content is wrong'
 end program test_join_failure_diagnostic

--- a/TEST/test_qflux_interface_diagnostic.f90
+++ b/TEST/test_qflux_interface_diagnostic.f90
@@ -10,7 +10,7 @@ program test_qflux_interface_diagnostic
     integer :: block_base(2), block_npassing(2), rows
     real(real64) :: eta, eta_grid(0:1), flux_kernel, flux_row(8), phi
     real(real64) :: phi_grid(2), solution(8, 3), source_rhs, rhs(8, 3)
-    real(real64) :: step_minus(2), step_plus(2), value
+    real(real64) :: projected, step_minus(2), step_plus(2), value
     logical :: found_counter_record
 
     block_base = [0, 4]
@@ -34,14 +34,15 @@ program test_qflux_interface_diagnostic
     read(iunit, '(a)', iostat=status) header
     if (status /= 0 .or. trim(header) /= &
         'sequence,tag,side,direction,laguerre,force,eta_index,eta,phi,' // &
-        'flux_kernel,source_rhs,source_solution') &
+        'flux_kernel,source_rhs,source_solution,' // &
+        'source_solution_orthogonal') &
         error stop 'FAIL: interface trace header is wrong'
 
     rows = 0
     found_counter_record = .false.
     do
         read(iunit, *, iostat=status) sequence, tag, side, direction, laguerre, &
-            force, band, eta, phi, flux_kernel, source_rhs, value
+            force, band, eta, phi, flux_kernel, source_rhs, value, projected
         if (status < 0) exit
         if (status > 0) error stop 'FAIL: interface trace row cannot be read'
         rows = rows + 1
@@ -54,7 +55,10 @@ program test_qflux_interface_diagnostic
                 .or. abs(phi - 2.0_real64) > 1.0e-15_real64 &
                 .or. abs(flux_kernel - 0.7_real64) > 1.0e-15_real64 &
                 .or. abs(source_rhs - rhs(7, 3)) > 1.0e-15_real64 &
-                .or. abs(value - solution(7, 3)) > 1.0e-15_real64) &
+                .or. abs(value - solution(7, 3)) > 1.0e-15_real64 &
+                .or. abs(projected - (solution(7, 3) &
+                - sum(solution(5:8, 3))/4.0_real64)) &
+                > 1.0e-15_real64) &
                 error stop 'FAIL: counter-passing trace mapping is wrong'
         end if
     end do


### PR DESCRIPTION
Stacked on #167 (do not merge before it; owner review).

The periodic-join Lorentz solvability correction acts through two channels: the per-band source-row subtractions (traced since #167) and a per-force scalar subtracted uniformly from both flux extraction rows (untraced until now).

**What this adds**

1. **Flux-channel trace rows** in the join-end trace: `flux_factor`, `flux_before`, `flux_after`, `flux_scale` per force, plus per-band `flux_correction_m`/`flux_correction_p` rows in the same `tag,side,force,band` format as the source side. Bookkeeping note now recorded in the module doc: `join_ripples` composes flux rows only into qflux and other flux rows, so this channel can shift the extracted transport coefficients but structurally cannot affect the pointwise reconstruction (relevant to the converged periodic-interface jump measured on the pinned #167 campaigns: the flux channel is excluded a priori for the jump, and the trace makes its gamma-level effect auditable).

2. **`NEO2_DISABLE_JOIN_LORENTZ_CORRECTION=1`** as a controlled A/B switch: the periodic solve keeps the uncorrected sources and extraction rows while the trace still records the would-be correction factors; a loud audit line marks any disabled run (runners must require it, mirroring the stage-2 attribution marker). This is the decisive experiment for the interface jump after the chain-end source-row channel was excluded by the corrected attribution pass B (flux_pumping run record 19526225): if the jump vanishes with the correction disabled, it is the correction's distributed footprint on the periodic solution and not attributable to any single-propagator edit.

**Tests**: `test_join_failure_diagnostic` extended for the new recorder signature, the flux rows (uniform per-force scalar), a non-finite flux-scale rejection, and the default-off state of the switch; passes. Full local ctest: 30/30 environment-independent tests pass; the 16 `external-data regression` tests fail for a missing `NEO2_TEST_PATH` on this machine (pre-existing, unrelated).

No behavior change without the env switch: the correction arithmetic is untouched and the new trace rows appear only when `NEO2_JOIN_END_TRACE_FILE` is set.