### PR TITLE
Complete preconditioned multispecies output

### DIFF
--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -987,7 +987,7 @@ CONTAINS
   !> -------------
   !> - writes file to disk in current folder
   !> - (?)
-  SUBROUTINE write_multispec_output_a()
+  SUBROUTINE write_multispec_output_a(final_y)
 
     use nrtype
     use er_rotation_mod, only: Om_tE_to_MtOvR_spec
@@ -1006,6 +1006,8 @@ CONTAINS
     USE hdf5_tools
 
     ! ---------------------------------------------------------------!
+    ! input:
+    REAL(kind=dp), DIMENSION(:), OPTIONAL, INTENT(in) :: final_y
     ! local definitions:
     ! ---------------------------------------------------------------!
     REAL(kind=dp), DIMENSION(:), ALLOCATABLE :: y
@@ -1147,9 +1149,9 @@ CONTAINS
     ! HDF5 file name
     CHARACTER(len=30) :: file_name
 
-    ! copy y-vector (see definition in rhs_kin.f90)
-    ALLOCATE(y(SIZE(y_ntv_mod,1)))
-    y = y_ntv_mod
+    ! Resolve the final geometry selected by the propagator.  The general
+    ! three-dimensional path does not initialize the legacy exchange array.
+    CALL resolve_ntv_output_geometry(y, final_y)
 
     ! R0, aiota, av_nabla_stor :
     rt0 = device%r0

--- a/NEO-2-QL/propagator.f90
+++ b/NEO-2-QL/propagator.f90
@@ -953,7 +953,7 @@ CONTAINS
       !! Extra output for NTV computations
       if (mpro%isMaster()) then
         IF(lsw_multispecies) THEN ! multi-species output
-          CALL write_multispec_output()
+          CALL write_multispec_output(y)
         ELSE ! single-species output
           CALL write_ntv_output(prop_a%p%qflux, y)
         END IF

--- a/NEO-2-QL/ripple_solver_axi_test.f90
+++ b/NEO-2-QL/ripple_solver_axi_test.f90
@@ -94,9 +94,9 @@ SUBROUTINE ripple_solver(                                 &
        apply_reconstructed_incoming_rows
   USE neo_magfie, ONLY : boozer_iota,boozer_curr_tor_hat, &
        boozer_curr_pol_hat,boozer_psi_pr_hat
-  USE ntv_mod, ONLY : isw_hel_drive,isw_m_phi_input,m_phi_input, &
+  USE ntv_mod, ONLY : isw_hel_drive,isw_m_phi_input,isw_qflux_NA,m_phi_input, &
        m_theta_hel,hel_brad_re,hel_brad_im,hel_phim_re,hel_phim_im, &
-       clight_hel => c,echarge_hel => e
+       qflux_symm_allspec,clight_hel => c,echarge_hel => e
   USE partpa_mod, ONLY : bmod0
   USE qflux_profile_mod, ONLY : qflux_contributions_from_flux_vector, &
        qflux_point_components_from_flux_vector, record_qflux_interface_traces
@@ -3046,6 +3046,14 @@ DO ispecp=0,num_spec-1
 ENDDO
 qflux_allspec=qflux_allspec_tmp
 IF(ALLOCATED(qflux_allspec_tmp)) DEALLOCATE(qflux_allspec_tmp)
+! Publish the completed multispecies matrix for the native output routine.
+! The Arnoldi solver performs the same handoff before returning; the
+! preconditioned solver historically only wrote the diagnostic text file.
+IF(isw_qflux_NA.EQ.0) THEN
+  IF(ALLOCATED(qflux_symm_allspec)) DEALLOCATE(qflux_symm_allspec)
+  ALLOCATE(qflux_symm_allspec(1:3,1:3,0:num_spec-1,0:num_spec-1))
+  qflux_symm_allspec=qflux_allspec
+END IF
 IF(mpro%getrank() .EQ. 0) THEN
   PRINT *,'qflux(1,1,:,:):'
   PRINT *,qflux_allspec(1,1,:,:)


### PR DESCRIPTION
## What changed

- pass the final resolved geometry to the multispecies output routine
- publish the completed preconditioned multispecies flux matrix to the native writer

## Why

The preconditioned solver gathered the correct matrix but left `qflux_symm_allspec` unallocated, while the output path could also read stale legacy geometry. Both faults occurred after the expensive physics solve.

## Validation

- full `fo` pipeline and focused output-geometry tests
- K3 r11 job 19756435_0 exited zero
- the job wrote a finite `neo2_multispecies_out.h5` with the expected D-matrix and geometry datasets

This remains stacked and unmerged for flux-pumping verification.
