### PR TITLE
Publish native closure inputs

### DIFF
--- a/NEO-2-QL/er_rotation_mod.f90
+++ b/NEO-2-QL/er_rotation_mod.f90
@@ -3,7 +3,8 @@ module er_rotation_mod
    implicit none
    private
 
-   public :: Om_tE_to_MtOvR_spec, MtOvR_spec_to_Om_tE, check_Om_tE_consistency
+   public :: Om_tE_to_MtOvR_spec, MtOvR_spec_to_Om_tE, &
+             Om_tE_to_Er, check_Om_tE_consistency
 
 contains
 
@@ -28,6 +29,16 @@ contains
       end if
       Om_tE = MtOvR_spec(1) * sqrt(2.0_dp * T_spec(1) / m_spec(1))
    end function MtOvR_spec_to_Om_tE
+
+   pure function Om_tE_to_Er(Om_tE, aiota, sqrtg_bctrvr_phi, c_light) result(Er)
+      real(dp), intent(in) :: Om_tE
+      real(dp), intent(in) :: aiota
+      real(dp), intent(in) :: sqrtg_bctrvr_phi
+      real(dp), intent(in) :: c_light
+      real(dp) :: Er
+
+      Er = Om_tE * aiota * sqrtg_bctrvr_phi / c_light
+   end function Om_tE_to_Er
 
    pure function check_Om_tE_consistency(MtOvR_spec, T_spec, m_spec, tol) &
       result(is_consistent)

--- a/NEO-2-QL/ntv_mod.f90
+++ b/NEO-2-QL/ntv_mod.f90
@@ -990,7 +990,7 @@ CONTAINS
   SUBROUTINE write_multispec_output_a(final_y)
 
     use nrtype
-    use er_rotation_mod, only: Om_tE_to_MtOvR_spec
+    use er_rotation_mod, only: Om_tE_to_MtOvR_spec, Om_tE_to_Er
     USE neo_control, ONLY: lab_swi
     USE device_mod, ONLY : device, surface
     USE mag_interface_mod, ONLY : mag_coordinates, &
@@ -1626,6 +1626,7 @@ CONTAINS
        IF (ALLOCATED(MtOvR_spec)) DEALLOCATE(MtOvR_spec)
        ALLOCATE(MtOvR_spec(0:num_spec-1))
        MtOvR_spec = Om_tE_to_MtOvR_spec(Om_tE, T_spec, m_spec)
+       Er = Om_tE_to_Er(Om_tE, aiota_loc, sqrtg_bctrvr_phi, c)
     END IF
 
     ! initialize HDF5 file
@@ -1669,6 +1670,14 @@ CONTAINS
     CALL h5_add(h5id_multispec, 'm_spec', m_spec, LBOUND(m_spec), UBOUND(m_spec), comment='mass of the species', unit='g')
     CALL h5_add(h5id_multispec, 'n_spec', n_spec, LBOUND(n_spec), UBOUND(n_spec), comment='density of the species', unit='1/cm^3')
     CALL h5_add(h5id_multispec, 'T_spec', T_spec, LBOUND(T_spec), UBOUND(T_spec), comment='temperature of the species', unit='erg')
+    CALL h5_add(h5id_multispec, 'dn_spec_ov_ds', dn_spec_ov_ds, &
+         LBOUND(dn_spec_ov_ds), UBOUND(dn_spec_ov_ds), &
+         comment='radial density derivative with respect to boozer_s', &
+         unit='1/cm^3')
+    CALL h5_add(h5id_multispec, 'dT_spec_ov_ds', dT_spec_ov_ds, &
+         LBOUND(dT_spec_ov_ds), UBOUND(dT_spec_ov_ds), &
+         comment='radial temperature derivative with respect to boozer_s', &
+         unit='erg')
     CALL h5_add(h5id_multispec, 'collpar_spec', collpar_spec, &
          LBOUND(collpar_spec), UBOUND(collpar_spec))
     CALL h5_add(h5id_multispec, 'nu_star_spec', nu_star_spec, &
@@ -1779,10 +1788,14 @@ CONTAINS
             LBOUND(MtOvR_spec), UBOUND(MtOvR_spec))
     END IF
 
-    ! add radial electric field and derived quantities (neoclassical only)
-    IF (isw_calc_Er .EQ. 1) THEN
+    ! add the radial electric field for computed and prescribed rotation
+    IF (isw_calc_Er .GE. 1) THEN
+       CALL h5_add(h5id_multispec, 'Er', Er, &
+            comment='radial electric field', unit='statV/cm')
+    END IF
 
-       CALL h5_add(h5id_multispec, 'Er', Er)
+    ! add derived quantities from the neoclassical electric-field solve
+    IF (isw_calc_Er .EQ. 1) THEN
 
        CALL h5_add(h5id_multispec, 'VthtB_spec', VthtB_spec, &
             LBOUND(VthtB_spec), UBOUND(VthtB_spec))

--- a/TEST/test_er_rotation.f90
+++ b/TEST/test_er_rotation.f90
@@ -1,7 +1,7 @@
 program test_er_rotation
    use nrtype, only: dp
    use er_rotation_mod, only: Om_tE_to_MtOvR_spec, MtOvR_spec_to_Om_tE, &
-                              check_Om_tE_consistency
+                              Om_tE_to_Er, check_Om_tE_consistency
    implicit none
 
    integer :: test_status
@@ -14,6 +14,7 @@ program test_er_rotation
    call test_consistency_check(test_status)
    call test_mode1_to_mode2_roundtrip(test_status)
    call test_half_omte_gives_half_mach(test_status)
+   call test_prescribed_rotation_to_Er(test_status)
 
    if (test_status == 0) then
       print *, "All tests passed!"
@@ -238,5 +239,34 @@ contains
 
       print *, "PASS: half Om_tE gives half MtOvR (linear scaling)"
    end subroutine test_half_omte_gives_half_mach
+
+   subroutine test_prescribed_rotation_to_Er(status)
+      integer, intent(inout) :: status
+      real(dp), parameter :: c_light = 2.9979e10_dp
+      real(dp), parameter :: Om_tE = -4.0e3_dp
+      real(dp), parameter :: aiota = 0.99_dp
+      real(dp), parameter :: sqrtg_bctrvr_phi = 2.5e4_dp
+      real(dp) :: Er, recovered_Om_tE
+
+      print *, "Testing prescribed Om_tE to Er conversion..."
+
+      Er = Om_tE_to_Er(Om_tE, aiota, sqrtg_bctrvr_phi, c_light)
+      recovered_Om_tE = c_light * Er / (aiota * sqrtg_bctrvr_phi)
+
+      if (abs(recovered_Om_tE - Om_tE) > epsilon(1.0_dp) * abs(Om_tE)) then
+         print *, "FAIL: prescribed Om_tE to Er conversion"
+         print *, "  Input Om_tE:", Om_tE
+         print *, "  Recovered Om_tE:", recovered_Om_tE
+         status = status + 1
+         return
+      end if
+      if (Er >= 0.0_dp) then
+         print *, "FAIL: Om_tE to Er conversion lost the input sign"
+         status = status + 1
+         return
+      end if
+
+      print *, "PASS: prescribed Om_tE to Er conversion"
+   end subroutine test_prescribed_rotation_to_Er
 
 end program test_er_rotation


### PR DESCRIPTION
## What changed

- write density and temperature radial derivatives to native multispecies HDF5
- reconstruct and write `Er` when `Om_tE` is prescribed
- add a tested `Om_tE`-to-`Er` conversion

## Why

The K3 outer-loop extractor needs the exact thermodynamic forces used with D31/D32. The native output contained the transport matrix and profiles but omitted their radial derivatives; prescribed-rotation mode also omitted the corresponding radial electric field.

## Impact

Downstream closures can consume one self-contained, unit-tagged native file instead of combining solver output with mutable side inputs.

## Validation

- `fo test er_rotation_test`
- `fo test ntv_output_geometry_test`
- `fo test multispecies_iteration_sync_test`
- full `fo` pipeline: build, tests and lint pass

This remains stacked and unmerged for flux-pumping verification.
