### PR TITLE
Use fortio through libneo for scientific I/O

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
+          # The latest stable NEO-2 baseline still uses the system libraries;
+          # the candidate build below uses dependency-free Fortio through libneo.
+          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev libhdf5-dev libnetcdf-dev libnetcdff-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
           version: 1.0
           execute_install_scripts: true
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev libhdf5-dev libnetcdf-dev libnetcdff-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
+          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
           version: 1.0
           execute_install_scripts: true
 
@@ -86,7 +86,7 @@ jobs:
           echo "data_dir=$(pwd)" >> $GITHUB_OUTPUT
           
       - name: Install libneo python required by NEO-2 python
-        run: pip install git+https://github.com/itpplasma/libneo.git
+        run: pip install git+https://github.com/itpplasma/libneo.git@afa0e4243e5e3f3e41110960f19cd0f340834988
 
       - name: Install NEO-2 python
         run: |

--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: git cmake make ninja-build gcc g++ gfortran jq lcov libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev libhdf5-dev libnetcdf-dev libnetcdff-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
+          packages: git cmake make ninja-build gcc g++ gfortran jq lcov libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
           version: 1.0
           execute_install_scripts: true
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev libhdf5-dev libnetcdf-dev libnetcdff-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
+          packages: git cmake make ninja-build gcc g++ gfortran jq libopenblas-dev liblapack-dev libsuitesparse-dev libfftw3-dev libgsl-dev python3-dev libevent-dev libnuma-dev libhwloc-dev libnl-3-dev libnl-route-3-dev libltdl-dev openmpi-bin openmpi-common libopenmpi-dev
           version: 1.0
           execute_install_scripts: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,6 @@ else()
   include(suitesparse)
 endif()
 
-find_package(HDF5 COMPONENTS C HL Fortran Fortran_HL REQUIRED)
-
 find_package(GSL REQUIRED)
 
 include_directories(${PROJECT_BINARY_DIR}/COMMON)

--- a/COMMON/CMakeLists.txt
+++ b/COMMON/CMakeLists.txt
@@ -102,7 +102,6 @@ target_link_libraries(common PUBLIC
   ${MPI_Fortran_LIBRARIES}
   BLAS::BLAS
   LAPACK::LAPACK
-  ${NETCDF_LIBS}
   -lz -lpthread
 )
 if(LEGACY_SUITESPARSE)

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 8d58a5eb55a376d6b5d8ae1c160ab7e2c9190b2c)
+    set(LIBNEO_REF 83cb783f67796dee4e4641c8435fbf15ae547059)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF ed5fea0fce0c68d510d61e4b80cdc05bdeb7ef76)
+    set(LIBNEO_REF 11fcdb5b856f02b8e72fe4b176c614563be51099)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 83cb783f67796dee4e4641c8435fbf15ae547059)
+    set(LIBNEO_REF 38ee3060ec5798fdd19d64b2aa9bd9e6940f8e69)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -2,6 +2,9 @@
 set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
+if(NOT DEFINED LIBNEO_REF)
+    set(LIBNEO_REF ed5fea0fce0c68d510d61e4b80cdc05bdeb7ef76)
+endif()
 find_or_fetch(libneo)
 
 ### FGSL
@@ -23,32 +26,3 @@ set(LIBFGSL ${FGSL_PATH}/.libs/libfgsl${CMAKE_STATIC_LIBRARY_SUFFIX} CACHE STRIN
 
 ### Directories of MPE
 set(MPE_PATH /afs/itp.tugraz.at/opt/mpe/1.3.0/)
-
-### NetCDF
-find_program(NF_CONFIG "nf-config")
-
-if (NF_CONFIG)
-execute_process(COMMAND nf-config --includedir
-                OUTPUT_VARIABLE NETCDFINCLUDE_DIR)
-execute_process(COMMAND nc-config --libdir
-				OUTPUT_VARIABLE NETCDFLIB_DIR)
-execute_process(COMMAND nf-config --flibs
-                OUTPUT_VARIABLE NETCDF_FLIBS)
-else()
-message(SEND_ERROR "nf-config not found. Please install libnetcdff-dev")
-endif()
-
-string(STRIP ${NETCDFINCLUDE_DIR} NETCDFINCLUDE_DIR)
-string(STRIP ${NETCDFLIB_DIR} NETCDFLIB_DIR)
-string(STRIP ${NETCDF_FLIBS} NETCDF_FLIBS)
-
-message(STATUS "NetCDF include path: " ${NETCDFINCLUDE_DIR})
-message(STATUS "NetCDF lib path: " ${NETCDFLIB_DIR})
-message(STATUS "NetCDF Fortran libs: " ${NETCDF_FLIBS})
-
-# Replace space by semicolon in the Fortran libs
-string(REPLACE " " ";" NETCDF_FLIBS ${NETCDF_FLIBS})
-
-include_directories(${NETCDFINCLUDE_DIR})
-link_directories(${NETCDFLIB_DIR})
-add_link_options(${NETCDF_FLIBS})

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 415d42037ca222abec587ddb08de56e040a59eba)
+    set(LIBNEO_REF 570fa39742055bcd1f72f48b67fe7c7fbbacb7f2)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF f3f241dea2c7dc25cf29731bb0a1328ff98f48c8)
+    set(LIBNEO_REF 8d58a5eb55a376d6b5d8ae1c160ab7e2c9190b2c)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 570fa39742055bcd1f72f48b67fe7c7fbbacb7f2)
+    set(LIBNEO_REF f3f241dea2c7dc25cf29731bb0a1328ff98f48c8)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 0ae82a0079373b23cecb82d383fa98b9ebed74bc)
+    set(LIBNEO_REF 415d42037ca222abec587ddb08de56e040a59eba)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 38ee3060ec5798fdd19d64b2aa9bd9e6940f8e69)
+    set(LIBNEO_REF afa0e4243e5e3f3e41110960f19cd0f340834988)
 endif()
 find_or_fetch(libneo)
 

--- a/COMMON/ProjectConfig.cmake.in
+++ b/COMMON/ProjectConfig.cmake.in
@@ -3,7 +3,7 @@ set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 include(Util)
 if(NOT DEFINED LIBNEO_REF)
-    set(LIBNEO_REF 11fcdb5b856f02b8e72fe4b176c614563be51099)
+    set(LIBNEO_REF 0ae82a0079373b23cecb82d383fa98b9ebed74bc)
 endif()
 find_or_fetch(libneo)
 

--- a/MULTI-SPEC-TOOLS/CMakeLists.txt
+++ b/MULTI-SPEC-TOOLS/CMakeLists.txt
@@ -12,14 +12,6 @@ add_executable(${PROJECT_EXE_NAME}
 	./h5merge_multispec.f90
 )
 
-set(Interface_Libs
-	hdf5::hdf5
-	hdf5::hdf5_hl
-	hdf5::hdf5_fortran
-	hdf5::hdf5_hl_fortran
-)
-
 target_link_libraries(${PROJECT_EXE_NAME}
 	LIBNEO::hdf5_tools
-	${Interface_Libs}
 )


### PR DESCRIPTION
## What changed

- Pins the final tested Libneo/Fortio migration revision by default while preserving `LIBNEO_REF` overrides.
- Removes direct NetCDF-Fortran discovery, include paths, and linkage.
- Removes direct HDF5 linkage from the multispecies merge tool.

This keeps NEO-2 on its existing compatibility APIs while moving their implementation to Fortio's deliberately limited ITP-use-case subset. It does not add general HDF5 support.

## Validation

- Clean remote CMake FetchContent build of Libneo and Fortio: passes.
- Focused `boozmn_read_test`: passes against the Fortio-backed stack.
- Libneo's downstream gate has independently completed NEO-2 successfully against this migration.
- Bare `fo` reaches the pre-existing missing FGSL archive (`fgsl/src/FGSL/.libs/libfgsl.a`) after static analysis; that external build prerequisite is unchanged by this migration.
